### PR TITLE
Resolve #32 Fix Font Paths

### DIFF
--- a/app/assets/stylesheets/global/_fonts.scss
+++ b/app/assets/stylesheets/global/_fonts.scss
@@ -27,19 +27,23 @@
 @import url("//hello.myfonts.net/count/37908e");
 
 @font-face {
-  font-family: 'SwiftNeueLTPro-Italic';
-  src: asset-url('37908E_0_0.woff') format('woff');
+  font-family: 'SwiftNeueLTPro';
+  src: asset-url('37908E_1_0.woff') format('woff');
+  font-style: normal;
 }
 @font-face {
-  font-family: 'SwiftNeueLTPro-Regular';
-  src: asset-url('37908E_1_0.woff') format('woff');
+  font-family: 'SwiftNeueLTPro';
+  src: asset-url('37908E_0_0.woff') format('woff');
+  font-style: italic;
 }
 
 @font-face {
   font-family: 'CalibreWeb-Semibold';
   src: asset-url('CalibreWeb-Semibold.woff') format('woff');
+  font-style: normal;
 }
 @font-face {
-  font-family: 'CalibreWeb-SemiboldItalic';
+  font-family: 'CalibreWeb-Semibold';
   src: asset-url('CalibreWeb-SemiboldItalic.woff') format('woff');
+  font-style: italic;
 }

--- a/app/assets/stylesheets/global/_fonts.scss
+++ b/app/assets/stylesheets/global/_fonts.scss
@@ -26,8 +26,20 @@
 /* @import must be at top of file, otherwise CSS will not work */
 @import url("//hello.myfonts.net/count/37908e");
 
-@font-face {font-family: 'SwiftNeueLTPro-Italic';src: asset-url('37908E_0_0.eot');src: asset-url('37908E_0_0.eot?#iefix') format('embedded-opentype'),asset-url('37908E_0_0.woff2') format('woff2'),asset-url('37908E_0_0.woff') format('woff'),asset-url('37908E_0_0.ttf') format('truetype');}
-@font-face {font-family: 'SwiftNeueLTPro-Regular';src: asset-url('37908E_1_0.eot');src: asset-url('37908E_1_0.eot?#iefix') format('embedded-opentype'),asset-url('37908E_1_0.woff2') format('woff2'),asset-url('37908E_1_0.woff') format('woff'),asset-url('37908E_1_0.ttf') format('truetype');}
+@font-face {
+  font-family: 'SwiftNeueLTPro-Italic';
+  src: asset-url('37908E_0_0.woff') format('woff');
+}
+@font-face {
+  font-family: 'SwiftNeueLTPro-Regular';
+  src: asset-url('37908E_1_0.woff') format('woff');
+}
 
-@font-face {font-family: 'CalibreWeb-Semibold';src: asset-url('CalibreWeb-Semibold.eot');src: asset-url('CalibreWeb-Semibold.eot?#iefix') format('embedded-opentype'),asset-url('CalibreWeb-Semibold.woff2') format('woff2'),asset-url('CalibreWeb-Semibold.woff') format('woff');}
-@font-face {font-family: 'CalibreWeb-SemiboldItalic';src: asset-url('CalibreWeb-SemiboldItalic.eot');src: asset-url('CalibreWeb-SemiboldItalic.eot?#iefix') format('embedded-opentype'),asset-url('CalibreWeb-SemiboldItalic.woff2') format('woff2'),asset-url('CalibreWeb-SemiboldItalic.woff') format('woff');}
+@font-face {
+  font-family: 'CalibreWeb-Semibold';
+  src: asset-url('CalibreWeb-Semibold.woff') format('woff');
+}
+@font-face {
+  font-family: 'CalibreWeb-SemiboldItalic';
+  src: asset-url('CalibreWeb-SemiboldItalic.woff') format('woff');
+}

--- a/app/assets/stylesheets/global/_fonts.scss
+++ b/app/assets/stylesheets/global/_fonts.scss
@@ -26,8 +26,8 @@
 /* @import must be at top of file, otherwise CSS will not work */
 @import url("//hello.myfonts.net/count/37908e");
 
-@font-face {font-family: 'SwiftNeueLTPro-Italic';src: url('37908E_0_0.eot');src: url('37908E_0_0.eot?#iefix') format('embedded-opentype'),url('37908E_0_0.woff2') format('woff2'),url('37908E_0_0.woff') format('woff'),url('37908E_0_0.ttf') format('truetype');}
-@font-face {font-family: 'SwiftNeueLTPro-Regular';src: url('37908E_1_0.eot');src: url('37908E_1_0.eot?#iefix') format('embedded-opentype'),url('37908E_1_0.woff2') format('woff2'),url('37908E_1_0.woff') format('woff'),url('37908E_1_0.ttf') format('truetype');}
+@font-face {font-family: 'SwiftNeueLTPro-Italic';src: asset-url('37908E_0_0.eot');src: asset-url('37908E_0_0.eot?#iefix') format('embedded-opentype'),asset-url('37908E_0_0.woff2') format('woff2'),asset-url('37908E_0_0.woff') format('woff'),asset-url('37908E_0_0.ttf') format('truetype');}
+@font-face {font-family: 'SwiftNeueLTPro-Regular';src: asset-url('37908E_1_0.eot');src: asset-url('37908E_1_0.eot?#iefix') format('embedded-opentype'),asset-url('37908E_1_0.woff2') format('woff2'),asset-url('37908E_1_0.woff') format('woff'),asset-url('37908E_1_0.ttf') format('truetype');}
 
-@font-face {font-family: 'CalibreWeb-Semibold';src: url('CalibreWeb-Semibold.eot');src: url('CalibreWeb-Semibold.eot?#iefix') format('embedded-opentype'),url('CalibreWeb-Semibold.woff2') format('woff2'),url('CalibreWeb-Semibold.woff') format('woff');}
-@font-face {font-family: 'CalibreWeb-SemiboldItalic';src: url('CalibreWeb-SemiboldItalic.eot');src: url('CalibreWeb-SemiboldItalic.eot?#iefix') format('embedded-opentype'),url('CalibreWeb-SemiboldItalic.woff2') format('woff2'),url('CalibreWeb-SemiboldItalic.woff') format('woff');}
+@font-face {font-family: 'CalibreWeb-Semibold';src: asset-url('CalibreWeb-Semibold.eot');src: asset-url('CalibreWeb-Semibold.eot?#iefix') format('embedded-opentype'),asset-url('CalibreWeb-Semibold.woff2') format('woff2'),asset-url('CalibreWeb-Semibold.woff') format('woff');}
+@font-face {font-family: 'CalibreWeb-SemiboldItalic';src: asset-url('CalibreWeb-SemiboldItalic.eot');src: asset-url('CalibreWeb-SemiboldItalic.eot?#iefix') format('embedded-opentype'),asset-url('CalibreWeb-SemiboldItalic.woff2') format('woff2'),asset-url('CalibreWeb-SemiboldItalic.woff') format('woff');}

--- a/app/assets/stylesheets/global/_vars.scss
+++ b/app/assets/stylesheets/global/_vars.scss
@@ -4,7 +4,7 @@ $font_size-small: 1rem;  // 16px
 $font_size-medium: 1.25rem; // 20px
 $font_size-large: 1.875rem;  // 30px
 
-$font_family-primary: 'SwiftNeueLTPro-Regular', serif;
+$font_family-primary: 'SwiftNeueLTPro', Georgia, serif;
 $font_family-secondary: 'CalibreWeb-Semibold', Helvetica, sans-serif;
 
 $color_bg-light: #ECFFFA;


### PR DESCRIPTION
This fixes fonts not working on staging/production by replacing the url helpers in the SCSS files with rails asset path helpers so the asset pipeline includes appropriate fingerprints.

Resolves #32.
