### PR TITLE
Resolve #49 Mobile Reponsive Fix

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <head>
     <%= render "/refinery/head" %>
     <%= render "/refinery/javascripts" %>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
   </head>
   <body id="<%= canonical_id @page %>" class="<%= view_template_class @page %>">
     <%= site_bar -%>


### PR DESCRIPTION
This fixes the mobile responsive issue by adding the viewport metatag as suggested by https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/UsingtheViewport/UsingtheViewport.html

Resolves #49.
