### PR TITLE
Resolve #36 Event SEO Meta Descriptions

### DIFF
--- a/vendor/extensions/events/app/controllers/refinery/events/admin/events_controller.rb
+++ b/vendor/extensions/events/app/controllers/refinery/events/admin/events_controller.rb
@@ -9,7 +9,7 @@ module Refinery
 
         # Only allow a trusted parameter "white list" through.
         def event_params
-          params.require(:event).permit(:title, :description, :start, :end, :image_id, :event_type, :address, :city, :state, :zipcode, :registration_link, :accessibility_note, :translation_note)
+          params.require(:event).permit(:title, :description, :start, :end, :image_id, :event_type, :address, :city, :state, :zipcode, :registration_link, :accessibility_note, :translation_note, :browser_title, :meta_description)
         end
       end
     end


### PR DESCRIPTION
* Whitelist the seo_meta parameters so that when a user submits an update to an event the app will actually save the SEO meta parameters.

Resolves #46.
