### PR TITLE
Resolve #45 Hide Header

### DIFF
--- a/app/views/refinery/_content_page.html.erb
+++ b/app/views/refinery/_content_page.html.erb
@@ -1,5 +1,5 @@
 <%= render_content_page(@page, {
-      :hide_sections => local_assigns[:hide_sections],
+      :hide_sections => [local_assigns[:hide_sections], :body_content_title],
       :can_use_fallback => !local_assigns[:show_empty_sections] && !local_assigns[:remove_automatic_sections]
     }) %>
 <%= render '/refinery/draft_page_message' if @page && @page.draft? -%>


### PR DESCRIPTION
This commit hides the header from the default show page because we now display it in the banner.

Resolves #45.
