### PR TITLE
Bump Rubyzip Version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ GEM
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
     ruby_dep (1.5.0)
-    rubyzip (1.2.1)
+    rubyzip (1.2.2)
     sass (3.5.7)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)


### PR DESCRIPTION
Bump rubyzip version due to security vulnerability.