### PR TITLE
Add underline to event link and overhaul link hover styling

### DIFF
--- a/app/assets/stylesheets/global/_base.scss
+++ b/app/assets/stylesheets/global/_base.scss
@@ -27,7 +27,6 @@ p {
 
 a {
   color: $color_bg-dark;
-  text-decoration: none;
   &.focus--keyboard {
     outline-style: solid;
     outline-color: $color_blue-medium;
@@ -44,6 +43,13 @@ a {
     background-color: $color_green-medium;
     color: $color_font-light;
     padding: 0.5em 1em;
+    &:hover {
+      background-color: $color_green-dark;
+      color: $color_font-light;
+    }
+  }
+  &:hover {
+    color: $color_green-medium;
   }
 }
 

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -10,6 +10,10 @@ footer {
   // Override normal green coloring
   a {
     color: $color_font-light;
+    text-decoration: none;
+    &:hover {
+      color: $color_green-light;
+    }
   }
 
 

--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -31,7 +31,10 @@ header {
     margin-top: 1rem;
   }
 
-  a.focus--keyboard .site-name {
-    color: $color_blue-medium;
+  a {
+    text-decoration: none;
+    &.focus--keyboard .site-name {
+      color: $color_blue-medium;
+    }
   }
 }

--- a/app/assets/stylesheets/partials/_search.scss
+++ b/app/assets/stylesheets/partials/_search.scss
@@ -26,12 +26,9 @@
     margin-top: 4rem;
     color: $color_bg-dark;
   }
-  a, a:visited {
-    color: $color_bg-dark;
-  }
   mark {
+    color: inherit;
     background: $color_bg-light;
-    color: $color_bg-dark;
   }
   p {
     margin: 0;

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -87,8 +87,11 @@
         display: block;
         padding-top: 100%;
       }
-      &:hover span.wrapper:after {
-        height: 0.5rem;
+      &:hover {
+        color: $color_bg-dark;
+        span.wrapper:after {
+          height: 0.5rem;
+        }
       }
       span.wrapper {
         position: absolute;
@@ -129,6 +132,12 @@
       }
       h2 {
         margin-top: 0;
+      }
+    }
+    a {
+      text-decoration: none;
+      &:not(.link-button):hover {
+        color: $color_green-medium;
       }
     }
   }


### PR DESCRIPTION
Resolves #71.

**Why is this change necessary?**
We've amended the link spec for event search results to include an underline, and most links on the site did not have a hover style.