### PR TITLE
Remove headline and subheadline

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,10 @@ Things you may want to cover:
 
 * Deployment instructions
 
-* ...
+# Special Instructions
+
+## Home Page
+
+In order to add content on the home page below the interruption bar
+("below the fold"), an editor must add a new page part called "Bottom", with the
+slug "bottom".

--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -36,4 +36,11 @@
       </div>
     </div>
   </div>
+  <% if @page.content_for(:bottom) %>
+    <div class="container">
+      <section class="content-column">
+        <%= raw @page.content_for(:bottom) %>
+      </section>
+    </div>
+  <% end %>
 </div>

--- a/config/initializers/refinery/pages.rb
+++ b/config/initializers/refinery/pages.rb
@@ -6,10 +6,10 @@ Refinery::Pages.configure do |config|
   # end
 
   # Configure global page default parts
-  config.default_parts = [{:title=>"Body", :slug=>"body"}, {:title=>"Headline", :slug=>"headline"}, {:title=>"Subheadline", :slug=>"subheadline"}]
+  config.default_parts = [{:title=>"Body", :slug=>"body"}]
 
   # Configure whether to allow adding new page parts
-  # config.new_page_parts = false
+  config.new_page_parts = true
 
   # Configure whether to enable marketable_urls
   # config.marketable_urls = true


### PR DESCRIPTION
Resolves #42 and allows content below interruption bar on home page

**Why is this change necessary?**
Headline and subheadline are deprecated.

**How does it address the issue?**
It removes headline and subheadline

**What side effects does it have?**
It also allows content below the interruption bar on the home page with a new page part called "bottom".
