### PR TITLE
Change 'Lets talk about' to 'Found out about'

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -38,7 +38,7 @@ en:
         search_site_for: "What do you want to know?"
         go: "Go"
       search:
-        search_label: "Let's Talk About"
+        search_label: "Find out about"
         search_site_for: 'Housi...'
         go: "Go"
     events:


### PR DESCRIPTION
Resolves #74.

**Why is this change necessary?**
The search label text no longer matched the design spec.