### PR TITLE
Fix menu being hidden by page_container overflow

### DIFF
--- a/app/assets/javascripts/drawer.js
+++ b/app/assets/javascripts/drawer.js
@@ -1,14 +1,16 @@
 function toggleDrawer() {
   var page = document.getElementById("page_container");
   var drawer = document.getElementById("drawer");
-  if (page.classList.contains("active")) {
-    page.classList.remove("active");
-    drawer.classList.remove("active");
+  var body = document.getElementsByTagName("body")[0];
+  if (page.classList.contains("menu-open")) {
+    page.classList.remove("menu-open");
+    drawer.classList.remove("menu-open");
+    body.classList.remove("menu-open");
     // Drawer starts out aria-hidden
     // Hidden removes the menu from the tab order until the menu is opened
     // Timeout matches CSS transition
     setTimeout(function() {
-      if (!page.classList.contains("active")) {
+      if (!page.classList.contains("menu-open")) {
         drawer.hidden = true;
         drawer.setAttribute('aria-hidden', 'true');
       }
@@ -18,8 +20,9 @@ function toggleDrawer() {
     drawer.setAttribute('aria-hidden', 'false');
     // Need time for hidden: false to take effect
     setTimeout(function() {
-      page.classList.add("active");
-      drawer.classList.add("active");
+      page.classList.add("menu-open");
+      drawer.classList.add("menu-open");
+      body.classList.add("menu-open");
     }, 80);
   }
 }

--- a/app/assets/stylesheets/global/_base.scss
+++ b/app/assets/stylesheets/global/_base.scss
@@ -5,6 +5,10 @@ body {
   font-family: $font_family-primary;
   overflow-x: hidden;
   min-height: 100vh;
+  &.menu-open {
+    height: 100vh;
+    overflow-y: hidden;
+  }
 }
 
 h1 {
@@ -88,9 +92,8 @@ input[type="submit"] {
 
 #page_container {
   transition-duration: 1s;
-  &.active {
+  &.menu-open {
     height: 100vh;
-    overflow: hidden;
     margin-right: 25rem;
     @include media(medium) {
       margin-right: 0rem;

--- a/app/assets/stylesheets/partials/_drawer.scss
+++ b/app/assets/stylesheets/partials/_drawer.scss
@@ -14,7 +14,7 @@
   border-left: 1px solid $color_bg-dark;
 
   @include media(medium) {
-    &.active {
+    &.menu-open {
       right: 0;
     }
   }


### PR DESCRIPTION
**Why is this change necessary?**
The page_container overflow which was required to fix weird vertical scrolling when the menu was open, also hid the menu. This applies the overflow hidden to the body instead.
