### PR TITLE
Fix language dropdown collision and web accessibility

### DIFF
--- a/app/assets/javascripts/drawer.js
+++ b/app/assets/javascripts/drawer.js
@@ -26,3 +26,15 @@ function toggleDrawer() {
     }, 80);
   }
 }
+
+function toggleLanguageList() {
+  var navLang = document.getElementById("navigation-language");
+  // var dropdown = navLang.getElementsByTagName("ul")[0];
+  if (navLang.classList.contains("menu-open")) {
+    navLang.classList.remove("menu-open");
+    navLang.setAttribute("aria-expanded", "false");
+  } else {
+    navLang.classList.add("menu-open");
+    navLang.setAttribute("aria-expanded", "true");
+  }
+}

--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -23,6 +23,16 @@ header {
     align-items: center;
     width: fit-content;
     transition-duration: 1.5s;
+    @include media(x-small) {
+      display: block;
+      nav {
+        position: absolute;
+        padding-right: 0;
+        width: max-content;
+        top: 100%;
+        right: 0;
+      }
+    }
   }
 
   .site-name {
@@ -31,6 +41,9 @@ header {
     align-items: center;
     img.wordmark {
       height: $font_size-small;
+      @include media(x-small) {
+        height: $font_size-xsmall;
+      }
     }
   }
 

--- a/app/assets/stylesheets/partials/_navigation_language.scss
+++ b/app/assets/stylesheets/partials/_navigation_language.scss
@@ -3,31 +3,52 @@
   font-size: 12px;
   min-width: 4em;
   z-index: 1;
-  padding-right: 1rem;
+
   padding-bottom: 0;
+
+  button {
+    padding: 0.5rem;
+    background-color: transparent;
+    border-style: solid;
+    border-color: transparent;
+    border-width: 1px 1px 0 1px;
+  }
 
   ul {
     position: absolute;
-    height: 1px;
-    overflow: hidden;
+    display: none;
     top: 100%;
     left: 0;
+    width: 100%;
     margin: 0;
-    padding: 1px 0;
+    padding: 0 0.5rem 0.5rem 0.5rem;
 
     li:not(:last-child) {
       margin-bottom: 0.25em;
     }
   }
 
-  &:hover ul, &:focus-within ul {
-    height: max-content;
-  }
-
-  a, span {
+  a, button {
     color: $color_font-light;
   }
-  a.focus--keyboard span {
+  button.focus--keyboard, a.focus--keyboard span {
     color: $color_blue-medium;
+  }
+
+  &.menu-open {
+    background-color: $color_bg-light;
+    ul {
+      display: block;
+      background-color: $color_bg-light;
+      border-style: solid;
+      border-color: $color_green-dark;
+      border-width: 0 1px 1px 1px;
+    }
+    button, a {
+      color: $color_green-dark;
+    }
+    button {
+      border-color: $color_green-dark;
+    }
   }
 }

--- a/app/assets/stylesheets/partials/_navigation_language.scss
+++ b/app/assets/stylesheets/partials/_navigation_language.scss
@@ -33,6 +33,7 @@
   }
   button.focus--keyboard, a.focus--keyboard span {
     color: $color_blue-medium;
+    background-color: $color_yellow-light;
   }
 
   &.menu-open {

--- a/app/views/refinery/shared/_navigation_language.html.erb
+++ b/app/views/refinery/shared/_navigation_language.html.erb
@@ -1,8 +1,13 @@
-<nav class="navigation-language" aria-label="Select language">
-  <span aria-label="Current language:">
+<nav id="navigation-language" class="navigation-language" aria-label="Select language">
+  <button
+    aria-label="Select langauge. Current language is <%= Refinery::I18n.config.locales[Mobility.locale] %>."
+    aria-expanded="false"
+    aria-haspopup="true"
+    onclick="toggleLanguageList()"
+  >
     <%= Refinery::I18n.config.locales[Mobility.locale] %> <%= fa_icon 'caret-down' %>
-  </span>
-  <ul class="navigation-language">
+  </button>
+  <ul class="navigation-language" role="menu" aria-label="Available languages">
     <% locales = (Refinery::I18n.config.frontend_locales.map { |l| "/#{l.to_s}" }).join("|") %>
     <% Refinery::I18n.config.frontend_locales.each do |locale| %>
       <li>


### PR DESCRIPTION
Resolves #108.

**Why is this change necessary?**
The language dropdown collided with the wordmark on small screens and it could be only accessed on hover.

**How does it address the issue?**
A button now opens the dropdown (try tabbing to it), and the button is moved below the hamburger for very small screens.