### PR TITLE
Update privacy policy link and fix styling on language disclaimer

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -13,9 +13,12 @@ header {
   .language-disclaimer {
     color: $color_font-light;
     background-color: $color_bg-black;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
+    width: 100%;
     font-size: $font_size-xsmall;
+    .container {
+      padding-top: 0.5rem;
+      padding-bottom: 0.5rem;
+    }
   }
 
   .header-content {

--- a/app/views/refinery/_footer.html.erb
+++ b/app/views/refinery/_footer.html.erb
@@ -13,7 +13,7 @@
         <a class="link-button" href="<%= CONSTANT_CONTACT_LANDING_PAGE %>" target="_blank"><%= t('footer.join_our_email_list') %></a>
       </div>
       <div class="bottom-links">
-        <a href="/privacy"><%= t('footer.privacy_policy') %></a>
+        <a href="/privacy-policy"><%= t('footer.privacy_policy') %></a>
       </div>
     </div>
   </div>

--- a/app/views/refinery/_header.html.erb
+++ b/app/views/refinery/_header.html.erb
@@ -1,7 +1,9 @@
 <header>
   <% if Mobility.locale != :en %>
-    <div class="container language-disclaimer">
-      <%= t('language_disclaimer') %>
+    <div class="language-disclaimer">
+      <div class="container ">
+        <%= t('language_disclaimer') %>
+      </div>
     </div>
   <% end %>
   <div class="container header-content">


### PR DESCRIPTION
**Why is this change necessary?**
If we have a page called "Privacy Policy" the slug will become "privacy-policy" and the link should reflect that. I also fixed a simple styling change in the language disclaimer.