### PR TITLE
Allow embedding and styling of YouTube videos

### DIFF
--- a/app/assets/javascripts/video-wrapper.js
+++ b/app/assets/javascripts/video-wrapper.js
@@ -1,0 +1,83 @@
+
+
+document.addEventListener("DOMContentLoaded", function() {
+  // Swap out all iframes for wrappers, video placeholders, and thumbnails
+  var videos = document.getElementsByTagName('iframe');
+  for (var i = 0; i < videos.length; i++) {
+    var video = videos[i];
+    var match = video.src.match(/https:\/\/www\.youtube\.com\/embed\/(.*)\?/);
+    var parent = video.parentNode;
+    if (match) {
+      var videoId = match[1];
+
+      var wrapper = document.createElement('div');
+      wrapper.setAttribute('data-video', videoId);
+      wrapper.classList.add('video-wrapper');
+
+      var videoPlaceholder = document.createElement('div');
+      videoPlaceholder.setAttribute('id', `video-${videoId}`);
+
+      var thumbnail = document.createElement('button');
+      thumbnail.classList.add('thumbnail');
+      thumbnail.setAttribute('id', `video-button-${videoId}`);
+      thumbnail.style.backgroundImage = `url(http://img.youtube.com/vi/${videoId}/maxresdefault.jpg)`;
+
+      wrapper.appendChild(videoPlaceholder);
+      wrapper.appendChild(thumbnail);
+      parent.replaceChild(wrapper, video);
+    } else {
+      parent.removeChild(video);
+    }
+  }
+
+  //youtube script
+  var tag = document.createElement('script');
+  tag.src = "//www.youtube.com/iframe_api";
+  var firstScriptTag = document.getElementsByTagName('script')[0];
+  firstScriptTag.parentNode.insertBefore(tag, firstScriptTag);
+});
+
+function onYouTubeIframeAPIReady() {
+  // When the YouTube API is ready, set up the video player
+  var videos = document.getElementsByClassName('video-wrapper');
+
+  for (var i = 0; i < videos.length; i++) {
+    var video = videos[i];
+    var videoId = video.getAttribute('data-video');
+    var button = document.getElementById(`video-button-${videoId}`);
+    var playWhenReady = false;
+    var playerReady = false;
+    var player = new YT.Player(`video-${videoId}`, {
+      height: '244',
+      width: '434',
+      videoId: videoId,
+      playerVars: {
+        'autoplay': 0,
+        'rel': 0,
+        'showinfo': 0
+      },
+      events: {
+        'onStateChange': function(event) {
+          if (event.data == YT.PlayerState.PLAYING) {
+            button.style.display = 'none';
+          }
+        },
+        'onReady': function() {
+          playerReady = true;
+          if (playWhenReady) {
+            player.playVideo();
+          }
+        }
+      }
+    });
+
+    button.onclick = function() {
+      button.classList.add('readying');
+      if (playerReady) {
+        player.playVideo();
+      } else {
+        playWhenReady = true;
+      }
+    };
+  }
+}

--- a/app/assets/javascripts/video-wrapper.js
+++ b/app/assets/javascripts/video-wrapper.js
@@ -5,7 +5,7 @@ document.addEventListener("DOMContentLoaded", function() {
   var videos = document.getElementsByTagName('iframe');
   for (var i = 0; i < videos.length; i++) {
     var video = videos[i];
-    var match = video.src.match(/https:\/\/www\.youtube\.com\/embed\/(.*)\?/);
+    var match = video.src.match(/https:\/\/www\.youtube\.com\/embed\/([^\?]*)(?:\?|$)/);
     var parent = video.parentNode;
     if (match) {
       var videoId = match[1];

--- a/app/assets/stylesheets/global/_base.scss
+++ b/app/assets/stylesheets/global/_base.scss
@@ -152,6 +152,52 @@ input[type="submit"] {
   }
 }
 
+iframe {
+  max-width: 100%;
+}
+
+.video-wrapper {
+  position: relative;
+  width: 100%;
+  height: 0;
+  padding-bottom: 56%;
+  iframe {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
+  }
+  button.thumbnail {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    left: 0;
+    top: 0;
+    background-size: cover;
+    background-position: center;
+    border: none;
+    &:after {
+      content: ' ';
+      display: block;
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      border-left: 60px solid rgba(255, 255, 255, 0.6);
+      transition-duration: 0.5s;
+      border-top: 30px solid transparent;
+      border-bottom: 30px solid transparent;
+      transform: translate(-50%, -50%);
+    }
+    &:hover:after {
+      border-left-color: rgba(255, 255, 255, 0.9);
+    }
+    &.readying:after {
+      border-left-color: rgba(255, 255, 255, 0);
+    }
+  }
+}
+
 .banner {
   background-color: $color_bg-dark;
   position: relative;

--- a/config/application.rb
+++ b/config/application.rb
@@ -15,5 +15,9 @@ module Digitalhub
     # Application configuration can go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
+
+    # To allow embedding YouTube videos
+    config.action_view.sanitized_allowed_tags = %w( iframe )
+    config.action_view.sanitized_allowed_attributes = %w( src frameborder webkitAllowFullScreen mozallowfullscreen allowFullScreen )
   end
 end

--- a/config/initializers/refinery/core.rb
+++ b/config/initializers/refinery/core.rb
@@ -40,4 +40,5 @@ Refinery::Core.configure do |config|
   # Specify the order Refinery plugins appear in the admin view.
   # Plugins in the list are placed, as ordered, before any plugins not in the list.
   # config.plugin_priority = %w(refinery_pages refinery_images)
+
 end

--- a/config/initializers/refinery/pages.rb
+++ b/config/initializers/refinery/pages.rb
@@ -74,10 +74,15 @@ Refinery::Pages.configure do |config|
   # (https://github.com/flavorjones/loofah/blob/v2.0.3/lib/loofah/html5/whitelist.rb#L151)
   # config.add_whitelist_elements = ["source", "track"]
 
+  config.add_whitelist_elements = %w( iframe )
+
   # You can add new HTML attributes not already supported by Loofah::HTML5::WhiteList::ALLOWED_ATTRIBUTES
   # For more information on whitelist see ALLOWED_ATTRIBUTES
   # (https://github.com/flavorjones/loofah/blob/v2.0.3/lib/loofah/html5/whitelist.rb#L152)
   # config.add_whitelist_attributes = ["kind", "srclang", "placeholder", "controls", "required"]
+
+  # Specifically strip width and height so that we can style the player with CSS
+  config.add_whitelist_attributes = %w( src frameborder webkitAllowFullScreen mozallowfullscreen allowFullScreen )
 
   # You can configure the site so that the home page is a model-index page
   # config.home_page_path = "/"


### PR DESCRIPTION
Resolves #96.

**Why is this change necessary?**
YouTube's embedded iframes were stripped out on the actual pages and were not styled according to the mocks.
