### PR TITLE
Fix repeating background and content-column in IE

### DIFF
--- a/app/assets/images/triangle_background.svg
+++ b/app/assets/images/triangle_background.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 538.909 1419.943">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 538.909 1419.943" preserveAspectRatio="none slice">
   <defs>
     <style>
       .cls-1, .cls-4 {

--- a/app/assets/stylesheets/global/_base.scss
+++ b/app/assets/stylesheets/global/_base.scss
@@ -119,8 +119,8 @@ input[type="submit"] {
 }
 
 .content-column {
-  margin-left: calc(calc(calc(calc(100% - 6rem) / 7) * 3) + 3rem);
-  margin-right: calc(calc(calc(calc(100% - 6rem) / 7) * 1) + 1rem);
+  margin-left: calc((((100% - 6rem) / 7) * 3) + 3rem);
+  margin-right: calc((((100% - 6rem) / 7) * 1) + 1rem);
   @include media(medium) {
     margin-left: 0;
     margin-right: 0;
@@ -128,8 +128,8 @@ input[type="submit"] {
 }
 
 .event-content-column {
-  margin-left: calc(calc(calc(calc(100% - 6rem) / 7) * 3) + 3rem);
-  margin-right: calc(calc(calc(calc(100% - 6rem) / 7) * 0.5) + 1rem);
+  margin-left: calc((((100% - 6rem) / 7) * 3) + 3rem);
+  margin-right: calc((((100% - 6rem) / 7) * 0.5) + 1rem);
   @include media(medium) {
     margin-left: 0;
     margin-right: 0;

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -6,7 +6,7 @@
     font-size: 20px;
     font-weight: normal;
     background: $color_bg-dark image-url('triangle_background.svg');
-    background-size: 40%;
+    background-size: 25rem 65rem;
 
     a, a:hover, a:visited {
       color: white;
@@ -89,7 +89,7 @@
       }
 
       .content-column-one {
-        width: calc(calc(calc(calc(100% - 6rem) / 7) * 3) + 2rem);
+        width: calc((((100% - 6rem) / 7) * 3) + 2rem);
         @include media(small) {
           margin-bottom: 1rem;
           width: 100%;
@@ -100,7 +100,7 @@
       }
       .content-column-two {
         flex: 1;
-        margin-right: calc(calc(calc(calc(100% - 6rem) / 7) * 1) + 1rem);
+        margin-right: calc((((100% - 6rem) / 7) * 1) + 1rem);
         margin-left: 1rem;
         @include media(small) {
           width: 100%;


### PR DESCRIPTION
**Why is this change necessary?**
Apparently IE doesn't like nested calc operations with the calc function name, and it does not scale and repeat svg backgrounds by default.