### PR TITLE
Update contact information

### DIFF
--- a/app/views/refinery/_footer.html.erb
+++ b/app/views/refinery/_footer.html.erb
@@ -24,8 +24,8 @@
     </div>
     <div class="footer-contact-information">
       <span>60 Temple Pl., Boston, MA 02111</span>
-      <span><a href="tel:16174512770">617 - 451 - 2770</a></span>
-      <span><a href="mailto:hello@digitalhub.com">hello@digitalhub.com</a></span>
+      <span><a href="tel:16179330700">617 - 933 - 0700</a></span>
+      <span><a href="mailto:metrocommon@mapc.org">metrocommon@mapc.org</a></span>
     </div>
     <div class="footer-right">
       <%= t('footer.follow_mapc') %>


### PR DESCRIPTION
Resolves #121.

**Why is this change necessary?**
Our MAPC contact information was out of date.