### PR TITLE
Use local in privacy policy link

### DIFF
--- a/app/views/refinery/_footer.html.erb
+++ b/app/views/refinery/_footer.html.erb
@@ -13,7 +13,7 @@
         <a class="link-button" href="<%= CONSTANT_CONTACT_LANDING_PAGE %>" target="_blank"><%= t('footer.join_our_email_list') %></a>
       </div>
       <div class="bottom-links">
-        <a href="/privacy-policy"><%= t('footer.privacy_policy') %></a>
+        <a href="<%= (Mobility.locale != Refinery::I18n.config.default_locale ? "/#{Mobility.locale.to_s}" : "") %>/privacy-policy"><%= t('footer.privacy_policy') %></a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**Why is this change necessary?**
If a user is viewing the site in a different language and they click on the privacy policy link, they'll end up on the english version. This simply adds the appropriate locale prefix to that link.

I have to imagine there is a better helper function that already exists, but I haven't found it yet.