### PR TITLE
Resolve #136 Event Index Crashing

### DIFF
--- a/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
+++ b/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
@@ -8,15 +8,9 @@ module Refinery
       def index
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @event in the line below:
-        now = DateTime.now
-        now_nozone = DateTime.new(now.year, now.month, now.day, now.hour, now.minute, now.second)
-        in_next_year, next_month = (now_nozone.month + 1).divmod(12)
-        year = in_next_year > 0 ? now_nozone.year + 1 : now_nozone.year
-        beginning_of_next_month = DateTime.new(year, next_month, 1, 0, 0, 0)
-        end_of_next_month = DateTime.new(year, next_month, -1, -1, -1, -1)
 
-        @upcoming_events = ::Refinery::Events::Event.where(start: now_nozone..beginning_of_next_month)
-        @events_next_month = ::Refinery::Events::Event.where(start: beginning_of_next_month..end_of_next_month)
+        @upcoming_events = ::Refinery::Events::Event.where(start: DateTime.now..DateTime.now.at_end_of_month)
+        @events_next_month = ::Refinery::Events::Event.where(start: DateTime.now.at_beginning_of_month.next_month..DateTime.now.at_end_of_month.next_month)
         present(@page)
       end
 


### PR DESCRIPTION
* Fix event index page crashing on 0 value for next_month by refactoring @upcoming_events to use ActiveSupport helper methods that are more clear.
