### PR TITLE
Update events text

### DIFF
--- a/vendor/extensions/events/config/locales/en.yml
+++ b/vendor/extensions/events/config/locales/en.yml
@@ -30,7 +30,7 @@ en:
           translation: "Translations"
           other: Other Events
         index:
-          heading: "These are the events"
+          heading: "Join us for an event!"
           upcoming: "Upcoming"
           next_month: "Next Month"
   activerecord:


### PR DESCRIPTION
* Update events text per request from designer.

# Why is this change necessary?
People did not like the event heading. So we received a request to change it.

# How does it address the issue?
It changes the event heading.
