### PR TITLE
Display Past Events

### DIFF
--- a/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
+++ b/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
@@ -12,6 +12,7 @@ module Refinery
         @upcoming_events = ::Refinery::Events::Event.where(start: DateTime.now..DateTime.now.at_end_of_month)
         @events_next_month = ::Refinery::Events::Event.where(start: DateTime.now.at_beginning_of_month.next_month..DateTime.now.at_end_of_month.next_month)
         present(@page)
+        @past_events = ::Refinery::Events::Event.where('start < ?', DateTime.now)
       end
 
       def show

--- a/vendor/extensions/events/app/views/refinery/events/events/index.html.erb
+++ b/vendor/extensions/events/app/views/refinery/events/events/index.html.erb
@@ -16,11 +16,23 @@
       <div class="partial EventsIndex">
         <h2><%= t('refinery.events.events.index.heading') %></h2>
         <h3><%= t('refinery.events.events.index.upcoming') %></h3>
-        <%= render partial: 'refinery/events/events/event_list', locals: { events: @upcoming_events } %>
+        <% if @upcoming_events.present? %>
+          <%= render partial: 'refinery/events/events/event_list', locals: { events: @upcoming_events } %>
+        <% else %>
+          No upcoming events.
+        <% end %>
         <h3><%= t('refinery.events.events.index.next_month') %></h3>
-        <%= render partial: 'refinery/events/events/event_list', locals: { events: @events_next_month } %>
+        <% if @events_next_month.present? %>
+          <%= render partial: 'refinery/events/events/event_list', locals: { events: @events_next_month } %>
+        <% else %>
+          No events this month.
+        <% end %>
         <h3><%= t('refinery.events.events.index.past') %></h3>
-        <%= render partial: 'refinery/events/events/event_list', locals: { events: @past_events } %>
+        <% if @past_events.present? %>
+          <%= render partial: 'refinery/events/events/event_list', locals: { events: @past_events } %>
+        <% else %>
+         No past events.
+       <% end %>
       </div>
     </div>
   </div>

--- a/vendor/extensions/events/app/views/refinery/events/events/index.html.erb
+++ b/vendor/extensions/events/app/views/refinery/events/events/index.html.erb
@@ -19,6 +19,8 @@
         <%= render partial: 'refinery/events/events/event_list', locals: { events: @upcoming_events } %>
         <h3><%= t('refinery.events.events.index.next_month') %></h3>
         <%= render partial: 'refinery/events/events/event_list', locals: { events: @events_next_month } %>
+        <h3><%= t('refinery.events.events.index.past') %></h3>
+        <%= render partial: 'refinery/events/events/event_list', locals: { events: @past_events } %>
       </div>
     </div>
   </div>

--- a/vendor/extensions/events/config/locales/en.yml
+++ b/vendor/extensions/events/config/locales/en.yml
@@ -33,6 +33,7 @@ en:
           heading: "Join us for an event!"
           upcoming: "Upcoming"
           next_month: "Next Month"
+          past: "Past Events"
   activerecord:
     attributes:
       'refinery/events/event':

--- a/vendor/extensions/events/config/locales/es.yml
+++ b/vendor/extensions/events/config/locales/es.yml
@@ -22,6 +22,7 @@ es:
       events:
         show:
           other: Otros events
+          past: Eventos pasados
   activerecord:
     attributes:
       'refinery/events/event':

--- a/vendor/extensions/events/config/locales/fr.yml
+++ b/vendor/extensions/events/config/locales/fr.yml
@@ -21,6 +21,7 @@ fr:
       events:
         show:
           other: Autres Events
+          past: Événements passés
   activerecord:
     attributes:
       'refinery/events/event':

--- a/vendor/extensions/events/config/locales/ru.yml
+++ b/vendor/extensions/events/config/locales/ru.yml
@@ -21,6 +21,7 @@ ru:
       events:
         show:
           other: Другие Events
+          past: Прошедшие события
   activerecord:
     attributes:
       'refinery/events/event':

--- a/vendor/extensions/events/config/locales/zh.yml
+++ b/vendor/extensions/events/config/locales/zh.yml
@@ -23,6 +23,7 @@ zh:
       events:
         show:
           other: 其他 Events
+          past: 过去的事
   activerecord:
     attributes:
       'refinery/events/event':


### PR DESCRIPTION
This commit displays previous events in a new previous events section on the events page.
