### PR TITLE
Resolve #181 Question Enum in Admin Panel

### DIFF
--- a/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_form.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_form.html.erb
@@ -11,8 +11,15 @@
   </div>
 
   <div class='field'>
-    <%= f.label :question -%>
-    <%= f.number_field :question -%>
+    <h3>Question</h3>
+    <%= f.label :question, value: 'question1' do %>
+      <%= f.radio_button(:question, 'question1') %>
+      Congratulations! You get to ask someone in the year 2050 about what life is like! What do you want to know?
+    <% end %>
+    <%= f.label :question, value: 'question2' do %>
+      <%= f.radio_button(:question, 'question2') %>
+      In your dream future, what do you want life to be like for children when it comes to housing?
+    <% end %>
   </div>
 
   <div class='field'>
@@ -24,7 +31,7 @@
 
   <div class='field'>
     <%= f.label :display -%>
-    <%= f.check_box :display, :checked => @story[:display] -%>
+    <%= f.check_box :display, :checked => @story[:display] %>
   </div>
 
   <%= render '/refinery/admin/form_actions', f: f,


### PR DESCRIPTION
This updates the admin panel view to show the relevant question enum when an administrative user edits the story in the story part of the admin panel. We make this update to allow the user to see which question the answer/post was in response to.
