### PR TITLE
Resolve #184 Allow User to Submit Multiple Questions

### DIFF
--- a/db/migrate/20190205181335_add_title_to_stories.rb
+++ b/db/migrate/20190205181335_add_title_to_stories.rb
@@ -1,0 +1,6 @@
+class AddTitleToStories < ActiveRecord::Migration[5.2]
+  def change
+    add_column :refinery_stories, :title, :string
+    rename_column :refinery_stories, :name, :submitter_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_29_154725) do
+ActiveRecord::Schema.define(version: 2019_02_05_181335) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -224,12 +224,13 @@ ActiveRecord::Schema.define(version: 2019_01_29_154725) do
   end
 
   create_table "refinery_stories", force: :cascade do |t|
-    t.string "name"
+    t.string "submitter_name"
     t.integer "question"
     t.boolean "display"
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "title"
   end
 
   create_table "refinery_story_translations", force: :cascade do |t|

--- a/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
+++ b/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
@@ -23,12 +23,6 @@ module Refinery
         present(@page)
       end
 
-    private
-
-      def story_params
-        params.require(:story).permit(:name, :question, :response, :display)
-      end
-
     protected
 
       def find_all_events

--- a/vendor/extensions/stories/app/controllers/refinery/stories/admin/stories_controller.rb
+++ b/vendor/extensions/stories/app/controllers/refinery/stories/admin/stories_controller.rb
@@ -4,13 +4,13 @@ module Refinery
       class StoriesController < ::Refinery::AdminController
 
         crudify :'refinery/stories/story',
-                :title_attribute => 'name'
+                :title_attribute => 'title'
 
         private
 
         # Only allow a trusted parameter "white list" through.
         def story_params
-          params.require(:story).permit(:name, :question, :response, :display)
+          params.require(:story).permit(:title, :question, :response, :display, :submitter_name)
         end
       end
     end

--- a/vendor/extensions/stories/app/controllers/refinery/stories/stories_controller.rb
+++ b/vendor/extensions/stories/app/controllers/refinery/stories/stories_controller.rb
@@ -56,7 +56,7 @@ module Refinery
     private
 
       def story_params
-        params.require(:story).permit(:name, :question, :video, :response, :audio)
+        params.require(:story).permit(:title, :question, :video, :response, :audio, :submitter_name)
       end
 
     protected

--- a/vendor/extensions/stories/app/models/refinery/stories/story.rb
+++ b/vendor/extensions/stories/app/models/refinery/stories/story.rb
@@ -1,3 +1,4 @@
+require 'pry-byebug'
 module Refinery
   module Stories
     class Story < Refinery::Core::BaseModel
@@ -5,13 +6,14 @@ module Refinery
       has_one_attached :video
       has_one_attached :audio
       validate :has_attached_story
+      before_validation :generate_title
       after_save :create_transcript
-      enum question: [:question1, :question2, :question3]
+      enum question: [:question1, :question2]
 
       extend Mobility
       translates :response
 
-      validates :name, :presence => true, :uniqueness => true
+      validates :title, :presence => true, :uniqueness => true
 
       # To enable admin searching, add acts_as_indexed on searchable fields, for example:
       #
@@ -30,6 +32,10 @@ module Refinery
         elsif response.blank? && audio.attached?
           TranscriptionWorker.perform_async(id)
         end
+      end
+
+      def generate_title
+        self.title = submitter_name + ' | ' + question
       end
     end
   end

--- a/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_form.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_form.html.erb
@@ -6,8 +6,8 @@
   <%= render '/refinery/admin/locale_picker',
               :current_locale => Mobility.locale %>
   <div class='field'>
-    <%= f.label :name -%>
-    <%= f.text_field :name, :class => 'larger widest' -%>
+    <%= f.label :submitter_name -%>
+    <%= f.text_field :submitter_name, :class => 'larger widest' -%>
   </div>
 
   <div class='field'>
@@ -37,7 +37,7 @@
   <%= render '/refinery/admin/form_actions', f: f,
              continue_editing: false,
              delete_title: t('delete', scope: 'refinery.stories.admin.stories.story'),
-             delete_confirmation: t('message', scope: 'refinery.admin.delete', title: @story.name),
+             delete_confirmation: t('message', scope: 'refinery.admin.delete', title: @story.title),
              cancel_url: refinery.stories_admin_stories_path -%>
 <% end -%>
 

--- a/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_story.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_story.html.erb
@@ -1,6 +1,6 @@
 <li class='clearfix record <%= cycle("on", "on-hover") %>' id="<%= dom_id(story) -%>">
   <span class='title'>
-    <%= story.name %>
+    <%= story.title %>
   </span>
 
   <span class='preview'></span>
@@ -10,6 +10,6 @@
     <%= action_icon(:edit,    refinery.edit_stories_admin_story_path(story), t('.edit') ) %>
     <%= action_icon(:delete,  refinery.stories_admin_story_path(story), t('.delete'),
       { class: "cancel confirm-delete",
-        data: {confirm: t('message',  scope: 'refinery.admin.delete', title: story.name)}}  ) %>
+        data: {confirm: t('message',  scope: 'refinery.admin.delete', title: story.title)}}  ) %>
   </span>
 </li>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_form.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_form.html.erb
@@ -19,8 +19,8 @@
     </div>
 
     <div class="field name">
-      <h4><%= form.label :name, 'Name (required)' %></h4>
-      <%= form.text_field :name %>
+      <h4><%= form.label :submitter_name, 'Name (required)' %></h4>
+      <%= form.text_field :submitter_name %>
     </div>
 
 

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/show.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/show.html.erb
@@ -6,7 +6,7 @@
   </div>
 </div>
 <% content_for :body_content_title do %>
-  <%= @story.name %>
+  <%= @story.submitter_name %>
 <% end %>
 
 <% content_for :body do %>


### PR DESCRIPTION
In order to allow a user to create a response to a each question we must create a generated attribute for the title that is a combination of the name and question being answered.

This commit also removes the unused question3 enum.

We also remove the unused story_params method in the events_controller since it should not have been introduced in a previous commit.