### PR TITLE
Resolve #208 No Question Bug

### DIFF
--- a/vendor/extensions/stories/app/models/refinery/stories/story.rb
+++ b/vendor/extensions/stories/app/models/refinery/stories/story.rb
@@ -34,6 +34,7 @@ module Refinery
       end
 
       def generate_title
+        return nil if question.blank? || submitter_name.blank?
         self.title = submitter_name + ' | ' + question
       end
     end


### PR DESCRIPTION
This resolves #208 by returning nil as the value for title if the question or submitter names are blank. This will then cause the user interface to display a more friendly error message instead of hard crashing.