### PR TITLE
Resolve #155 Show Transcriptions in Feed

### DIFF
--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -64,6 +64,10 @@
     font-size: $font_size-xsmall;
   }
 
+  .transcript {
+    margin-top: 1rem;
+  }
+
   .quote-mark {
     display: inline-block;
     top: 8px;

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
@@ -9,4 +9,13 @@
   <% else %>
     Sorry, there was an error displaying the content.
   <% end %>
-</div>
+  <% if (media.video.attached? || media.audio.attached?) && media.response.present? %>
+    <div class="transcript">
+      <p class="accordion-title">Transcript</p>
+      <p class="accordion-content">
+        <span class="quote-mark">“</span>
+        <%= media.response %>
+      </p>
+    </div>
+  <% end %>
+  </div>


### PR DESCRIPTION
* Show transcriptions in the story feed so folks can read the audio and video recordings as well as listen to them. This improves accessibility of the information for the user.