### PR TITLE
Time Zone Fix

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'webpacker', '~> 3.5'
 gem 'google-cloud-speech'
 gem 'sidekiq'
 gem 'google-cloud-storage'
+gem 'local_time'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -339,6 +339,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    local_time (2.1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -584,6 +585,7 @@ DEPENDENCIES
   guard-livereload
   guard-rspec
   listen (>= 3.0.5, < 3.2)
+  local_time
   mini_magick
   pg
   pry-byebug

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,3 +13,4 @@
 //= require rails-ujs
 //= require activestorage
 //= require_tree .
+//= require local-time

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,6 +10,7 @@ module Digitalhub
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.2
+    config.time_zone = 'Eastern Time (US & Canada)'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration can go into files in config/initializers

--- a/db/migrate/20190301155416_fix_event_times.rb
+++ b/db/migrate/20190301155416_fix_event_times.rb
@@ -1,0 +1,22 @@
+class FixEventTimes < ActiveRecord::Migration[5.2]
+  def change
+    reversible do |direction|
+      direction.up do
+        # Assumption: times are stored as UTC, but the stored times should have been in America/New_York
+        # Convert stored times to eastern and re-save as the correct UTC times
+        Refinery::Events::Event.all.each do |event|
+          event.update(start: ActiveSupport::TimeZone.new('America/New_York').local_to_utc(event.start),
+                       end: ActiveSupport::TimeZone.new('America/New_York').local_to_utc(event.end))
+        end
+      end
+
+      direction.down do
+        # Assume event.start is in UTC, move it to America/New_York time, but return in Time.UTC.
+        Refinery::Events::Event.all.each do |event|
+          event.update(start: ActiveSupport::TimeZone.new('America/New_York').utc_to_local(event.start),
+                       end: ActiveSupport::TimeZone.new('America/New_York').utc_to_local(event.end))
+        end
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_05_181335) do
+ActiveRecord::Schema.define(version: 2019_03_01_155416) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/vendor/extensions/events/app/views/refinery/events/events/_event_list.html.erb
+++ b/vendor/extensions/events/app/views/refinery/events/events/_event_list.html.erb
@@ -17,13 +17,13 @@
             </div>
             <div class="event-start">
               <span class="hidden-text"><%= t('refinery.events.on_date') %></span>
-              <span class="hidden-text"><%= event.start.strftime("%B %-d, %Y at %l:%M%p") %></span>
-              <span aria-hidden="true"><%= event.start.strftime("%b %-d - %l:%M%P") %></span>
+              <span class="hidden-text"><%= local_time(event.start, '%B %-d, %Y at %l:%M%p') %></span>
+              <span aria-hidden="true"><%= local_time(event.start, '%b %-d - %l:%M%P') %></span>
             </div>
             <div class="event-end">
               <span class="hidden-text"><%= t('refinery.events.on_date') %></span>
-              <span class="hidden-text"><%= event.end.strftime("%B %-d, %Y at %l:%M%p") %></span>
-              <span aria-hidden="true"><%= event.end.strftime("%b %-d - %l:%M%P") %></span>
+              <span class="hidden-text"><%= local_time(event.end, '%B %-d, %Y at %l:%M%p') %></span>
+              <span aria-hidden="true"><%= local_time(event.end, '%b %-d - %l:%M%P') %></span>
             </div>
           </div>
         </div>

--- a/vendor/extensions/events/app/views/refinery/events/events/show.html.erb
+++ b/vendor/extensions/events/app/views/refinery/events/events/show.html.erb
@@ -19,11 +19,12 @@
       <div class="event-time">
         <h2 class="hidden-text"><%= t('refinery.events.events.show.time') %></h2>
         <% if @event.end.day > @event.start.day %>
-          <p><%=@event.start.strftime("%A, %B %-d, %Y at %-l:%M%P")%> to</p>
-          <p><%=@event.start.strftime("%A, %B %-d, %Y at %-l:%M%P")%></p>
+          <p><%= local_time(@event.start, '%A, %B %-d, %Y at %-l:%M%P') %> to</p>
+          <p><%= local_time(@event.end, '%A, %B %-d, %Y at %-l:%M%P') %></p>
+
         <% else %>
-          <p><%=@event.start.strftime("%A, %B %-d, %Y")%></p>
-          <p><%=@event.start.strftime("%-l:%M%P")%> - <%=@event.end.strftime("%-l:%M%P")%></p>
+          <p><%= local_time(@event.start, '%A, %B %-d, %Y') %></p>
+          <p><%= local_time(@event.start, '%-l:%M%P') %> - <%= local_time(@event.end, '%-l:%M%P') %></p>
         <% end %>
       </div>
 


### PR DESCRIPTION
* Fix times in database to reflect actual UTC instead of local time.
* Add local_time gem to correctly display time in user’s local time.
* Fix event list bug that was displaying start instead fo end date for multi day events
* Set app time zone to Eastern Time going forward so admins have times submitted in the correct time zone.