### PR TITLE
Add bin/yarn to bin/setup

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -26,7 +26,7 @@ else
 end
 
   # Install JavaScript dependencies if using Yarn
-  # system('bin/yarn')
+  system('bin/yarn')
 
   # puts "\n== Copying sample files =="
   # unless File.exist?('config/database.yml')


### PR DESCRIPTION
Resolves # .

# Why is this change necessary?
Needed to add bin/yarn to setup in order to generate javascript files for the app to work.

# How does it address the issue?
By executing yarn in the setup script.

# What side effects does it have?
None.

