### PR TITLE
Change sort order of events

### DIFF
--- a/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
+++ b/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
@@ -8,11 +8,10 @@ module Refinery
       def index
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @event in the line below:
-
-        @upcoming_events = ::Refinery::Events::Event.where(start: DateTime.now..DateTime.now.at_end_of_month)
+        @upcoming_events = ::Refinery::Events::Event.where(start: DateTime.now..DateTime.now.at_end_of_month).sort {|a,b| a.start <=> b.start }
         @events_next_month = ::Refinery::Events::Event.where(start: DateTime.now.at_beginning_of_month.next_month..DateTime.now.at_end_of_month.next_month)
         present(@page)
-        @past_events = ::Refinery::Events::Event.where('start < ?', DateTime.now)
+        @past_events = ::Refinery::Events::Event.where('start < ?', DateTime.now).sort {|a,b| b.start <=> a.start }
       end
 
       def show

--- a/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
+++ b/vendor/extensions/events/app/controllers/refinery/events/events_controller.rb
@@ -8,10 +8,10 @@ module Refinery
       def index
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @event in the line below:
-        @upcoming_events = ::Refinery::Events::Event.where(start: DateTime.now..DateTime.now.at_end_of_month).sort {|a,b| a.start <=> b.start }
+        @upcoming_events = ::Refinery::Events::Event.where(start: DateTime.now..DateTime.now.at_end_of_month).order(start: :asc)
         @events_next_month = ::Refinery::Events::Event.where(start: DateTime.now.at_beginning_of_month.next_month..DateTime.now.at_end_of_month.next_month)
         present(@page)
-        @past_events = ::Refinery::Events::Event.where('start < ?', DateTime.now).sort {|a,b| b.start <=> a.start }
+        @past_events = ::Refinery::Events::Event.where('start < ?', DateTime.now).order(start: :desc)
       end
 
       def show


### PR DESCRIPTION
Resolves #231.

Why is this change necessary?
This change was necessary to present the grouping of event dates in a more intuitive manner.

How does it address the issue?
The dates are now sorted according to three groups: 
 1. Upcoming Events (sorted starting with the next nearest date and forward chronologically).
 2. Next Month (unchanged in this pull request)
3.  Past Events (sorted starting with the most recent date and backward chronologically.)

What are the potential side effects of this change? 
There are no side effects.
  


