### PR TITLE
Resolve #247 Asset Fingerprinting

### DIFF
--- a/app/views/partials/_one_box.html.erb
+++ b/app/views/partials/_one_box.html.erb
@@ -1,9 +1,9 @@
 <% type = nil if local_assigns[:type].nil? %>
 <% image = '' if local_assigns[:image].nil? %>
 
-<div 
+<div
   class="styled-box one-box <%= 'styled-box--half' if type == 'half' %>"
-  style="background-image: url('/assets/<%= image %>')"
+  style="background-image: url('<%= image_path(image) %>')"
 >
   <div class="styled-box__content">
     <div class="styled-box__title styled-box__title--block"><%= title %></div>


### PR DESCRIPTION
This uses the rails image_path helper to produce the correct image path in the CSS so that staging and production load fingerprinted assets correctly.
