### PR TITLE
Update hero rotation interval to 5 seconds actual.

### DIFF
--- a/app/javascript/packs/hero-rotation.js
+++ b/app/javascript/packs/hero-rotation.js
@@ -34,7 +34,7 @@ const loadImages = (images) => {
         loadImages(images[index]);
         index++
       }
-    }, i * 3000);
+    }, i * 6000);
   }
 };
 
@@ -51,7 +51,7 @@ const loadImage = (img) => {
   if (counter == 0) {
     setTimeout(() => {
       replay()
-    }, 4000);
+    }, 5000);
   }
 }
 


### PR DESCRIPTION
Resolves the actual timed rotation of hero images to be effectively 5 seconds per image.

# Why is this change necessary?
Although the code was set for 5 seconds, with the transition effect, they were changing a little faster than 5 seconds as timed. 

# How does it address the issue?
The interval in code is now set to 6 seconds, and the actual timed change results in 5 seconds.

# What side effects does it have?
None.