### PR TITLE
Resolve #258 Admin Audio Upload for Stories

### DIFF
--- a/app/workers/audio_extraction_worker.rb
+++ b/app/workers/audio_extraction_worker.rb
@@ -3,10 +3,9 @@ class AudioExtractionWorker
 
   def perform(story_id)
     story = Refinery::Stories::Story.find(story_id)
-    binary = story.video.download
-    path = "#{Dir.tmpdir}/#{story.video.filename.to_s}"
+    path = "#{Dir.tmpdir}/#{story.video.filename}"
     File.open(path, 'wb') do |file|
-       file.write(story.video.download)
+      file.write(story.video.download)
     end
     system "ffmpeg -i #{path} #{Dir.tmpdir}/#{story.video.key}.wav > log/#{Rails.env}.log 2>&1"
     story.audio.attach(io: File.open("#{Dir.tmpdir}/#{story.video.key}.wav"),

--- a/app/workers/transcription_worker.rb
+++ b/app/workers/transcription_worker.rb
@@ -4,15 +4,22 @@ class TranscriptionWorker
 
   def perform(story_id)
     story = Refinery::Stories::Story.find(story_id)
+    path = "#{Dir.tmpdir}/#{story.audio.filename}"
+    File.open(path, 'wb') do |file|
+      file.write(story.audio.download)
+    end
+    sample_rate_hertz = `ffprobe -show_entries stream=sample_rate -hide_banner -of default=noprint_wrappers=1:nokey=1 #{path}  2> /dev/null`
     speech = Google::Cloud::Speech.new(credentials: Rails.application.credentials.gcs)
-    config = { encoding:          :LINEAR16,
-             language_code:     "en-US"   }
+    config = { encoding: :LINEAR16,
+               language_code: "en-US",
+               sample_rate_hertz: sample_rate_hertz.strip.to_i }
     audio  = { uri: "gs://maps-digital-hub/#{story.audio.key}" }
 
     operation = speech.long_running_recognize(config, audio)
     operation.wait_until_done!
     raise operation.results.message if operation.error?
-
+    Rails.logger.info '=Google Cloud Response='
+    Rails.logger.info operation
     recognized_text = ''
     for i in 0..(operation.response['results'].length - 1) do
       recognized_text += operation.response['results'][i]['alternatives'][0]['transcript']

--- a/spec/workers/transcription_worker_spec.rb
+++ b/spec/workers/transcription_worker_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe TranscriptionWorker, type: :worker do
     end
 
     speech = double('Google::Cloud::Speech')
-    allow(speech).to receive(:long_running_recognize).with(hash_including(:encoding, :language_code), hash_including(:uri)) do
+    allow(speech).to receive(:long_running_recognize).with(hash_including(:encoding, :language_code, :sample_rate_hertz), hash_including(:uri)) do
       operation
     end
 

--- a/vendor/extensions/stories/app/controllers/refinery/stories/admin/stories_controller.rb
+++ b/vendor/extensions/stories/app/controllers/refinery/stories/admin/stories_controller.rb
@@ -10,7 +10,7 @@ module Refinery
 
         # Only allow a trusted parameter "white list" through.
         def story_params
-          params.require(:story).permit(:title, :question, :response, :display, :submitter_name)
+          params.require(:story).permit(:title, :question, :response, :display, :submitter_name, :audio, :video)
         end
       end
     end

--- a/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_form.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_form.html.erb
@@ -34,6 +34,18 @@
     <%= f.check_box :display, :checked => @story[:display] %>
   </div>
 
+  <div class="media-buttons">
+    <div class="field video-response">
+      <%= f.label :video, 'Upload Video' %>
+      <%= f.file_field :video, accept: "video/mp4,video/x-m4v,video/*", class: "actions" %>
+    </div>
+
+    <div class="field audio-response" id="audio-recording">
+      <%= f.label :video, 'Upload Audio' %>
+      <%= f.file_field :audio, accept: "audio/*", class: "actions" %>
+    </div>
+  </div>
+
   <%= render '/refinery/admin/form_actions', f: f,
              continue_editing: false,
              delete_title: t('delete', scope: 'refinery.stories.admin.stories.story'),


### PR DESCRIPTION
* Fix and refactor the transcription and audio_extraction_worker files to comport with Google’s updated API requirement
* We now need to tell Google our sampel rate in hertz so we have to use ffprobe to tell us this
* Add video and audio upload fields to the Refinery admin panel so that admin users can upload stories with multimedia from the admin panel.
