### PR TITLE
Bjs/about section padding and logo-v2

### DIFF
--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -69,14 +69,19 @@
     grid-template-columns: 13.875rem 38.875rem 11.06rem 39.375rem 16.875rem;
     grid-template-rows: 54.88rem;
     padding: 0;
-
+    
     font-family: $font_family-primary;
     background-color: #ffffff;
-
-    @include media($break_xsmall) {
+    
+    @include media($break_xlarge) {
+      grid-template-columns: 10.875rem 38.875rem 11.06rem 39.375rem 16.875rem;
+      grid-template-rows: 26.88rem;
+    }
+    
+    @include media($break_small) {
       display: grid;
       grid-template-columns: 1.56rem 26.25rem 2.31rem;
-      grid-template-rows: 39.68rem;
+      grid-template-rows: 35.2rem;
       padding: 0;
     }
 

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -66,16 +66,16 @@
   
   .regional-plan {
     display: grid;
-    grid-template-columns: 13.875rem 38.875rem 11.06rem 39.375rem 16.875rem;
+    grid-template-columns: 16.31rem 39.25rem 8.75rem 39.375rem;
     grid-template-rows: 54.88rem;
-    padding: 0;
     
     font-family: $font_family-primary;
     background-color: #ffffff;
     
     @include media($break_xlarge) {
-      grid-template-columns: 10.875rem 38.875rem 11.06rem 39.375rem 16.875rem;
-      grid-template-rows: 26.88rem;
+      grid-template-columns: 16.31rem 30.25rem 1fr;
+      grid-template-rows: 35rem;
+      margin-bottom: 4.56rem;
     }
     
     @include media($break_small) {
@@ -83,13 +83,15 @@
       grid-template-columns: 1.56rem 26.25rem 2.31rem;
       grid-template-rows: 35.2rem;
       padding: 0;
+      margin-bottom: 4.56rem;
     }
 
     &--triangle {
       grid-column-start: 2;
+      grid-column-end: 3;
       width: auto;
       height: auto;
-      padding-top: 8.94rem;
+      padding-top: 8.75rem;
       
       @include media($break_xlarge){
         display: none;
@@ -98,12 +100,15 @@
     
     &--description {
       grid-column-start: 4;
+      grid-column-end: 5;
       padding-top: 12rem;
 
       @include media($break_xlarge) {
         grid-column-start: 2;
-        // padding-top: 3.25rem;
-        padding: 0;
+        grid-column-end: 3;
+        font-size: .9375rem;
+        padding: 4.06rem 2.31rem 4.56rem .9375rem;
+        margin-bottom: 2rem;
       }
 
       &-title {
@@ -113,7 +118,8 @@
         
         @include media($break_xlarge) {
           font-size: 2.125rem;
-          padding: 0 12rem 0 0;
+          padding-right: 6rem;
+          width: 20rem;
         }
       }
       
@@ -123,7 +129,6 @@
         color: $v3-color_green-dark;
         
         @include media($break_xlarge) {
-          padding: 0 1.85rem 1rem 0;
           font-size: .9375rem;
         }
       }
@@ -143,7 +148,7 @@
         background-color: $v3-color_green-lightest;
         
         @include media($break_xlarge) {
-          margin: 0;
+          margin-top: 1.87rem;
           padding: .7rem 3.5rem .7rem 2.5rem;
         }
 

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -52,7 +52,7 @@
 
   .one-box-grid {
     padding: 0 8.3rem 10.625rem 13.875rem;
-
+    
     background: $v3-color_green-dark;
 
     p {
@@ -63,71 +63,63 @@
       padding: 0 1rem;
     }
   }
-
+  
   .regional-plan {
-    display: flex;
-    padding: 0 0 5rem 0;
-    align-items: center;
-    justify-content: center;
+    display: grid;
+    grid-template-columns: 13.875rem 38.875rem 11.06rem 39.375rem 16.875rem;
+    grid-template-rows: 54.88rem;
+    padding: 0;
 
     font-family: $font_family-primary;
     background-color: #ffffff;
 
-    @include media(x-large) {
-      padding: 0 1rem 5rem 1rem;
-    }
-
-    @include media(small) {
-      display: block;
-      padding: 0 1rem 5rem 1rem;
+    @include media($break_xsmall) {
+      display: grid;
+      grid-template-columns: 1.56rem 26.25rem 2.31rem;
+      grid-template-rows: 39.68rem;
+      padding: 0;
     }
 
     &--triangle {
-      flex: 1;
-      max-width: 622px;
-
-      margin: 1rem 8.5rem 8rem 0;
+      grid-column-start: 2;
       width: auto;
-      height: 28rem;
-
-      @include media(small) {
-        width: 100%;
-        margin-left: 0;
-      }
-      @include media(medium){
+      height: auto;
+      padding-top: 8.94rem;
+      
+      @include media($break_small){
         display: none;
       }
     }
-
+    
     &--description {
-      max-width: 622px;
-      margin-top: 1rem;
+      grid-column-start: 4;
+      padding-top: 12rem;
 
-      @include media($break_xsmall) {
-        margin-bottom: 1rem;
-        width: 100%;
-        h2 {
-          margin-bottom: 0.5rem;
-        }
+      @include media($break_small) {
+        grid-column-start: 2;
+        padding-top: 3.25rem;
       }
-
 
       &-title {
         font-family: $font_family-primary;
         color: $v3-color_green-dark;
-        font-size: 2.75rem;
-
-        @include media(small) {
-          font-size: 1.5rem;
+        font-size: 2.125rem;
+        
+        @include media($break_small) {
+          font-size: 2.125rem;
+          padding: 0 12rem 0 0;
         }
       }
-
-      &-text, h1, p{
-        align-content: center;
-        color: $v3-color_green-dark;
-        margin-bottom: 1rem;
+      
+      &-text, p{
         font-family: $font_family-primary;
         font-size: 1.25rem;
+        color: $v3-color_green-dark;
+        
+        @include media($break_small) {
+          padding: 0 1.85rem 1rem 0;
+          font-size: .9375rem;
+        }
       }
 
       &__button {
@@ -135,14 +127,19 @@
         margin-top: 2.5rem;
         padding: .7rem 3.5rem .7rem 2.5rem;
         border: 1px solid $v3-color_green-dark;
-
+        
         text-align: center;
         text-transform: uppercase;
         font-family: $font_family-secondary;
         letter-spacing: .1rem;
-
+        
         color: $v3-color_green-medium;
         background-color: $v3-color_green-lightest;
+        
+        @include media($break_small) {
+          margin: 0;
+          padding: .7rem 3.5rem .7rem 2.5rem;
+        }
 
         a {
           text-decoration: none;

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -86,7 +86,7 @@
       height: auto;
       padding-top: 8.94rem;
       
-      @include media($break_small){
+      @include media($break_xlarge){
         display: none;
       }
     }
@@ -95,9 +95,10 @@
       grid-column-start: 4;
       padding-top: 12rem;
 
-      @include media($break_small) {
+      @include media($break_xlarge) {
         grid-column-start: 2;
-        padding-top: 3.25rem;
+        // padding-top: 3.25rem;
+        padding: 0;
       }
 
       &-title {
@@ -105,7 +106,7 @@
         color: $v3-color_green-dark;
         font-size: 2.125rem;
         
-        @include media($break_small) {
+        @include media($break_xlarge) {
           font-size: 2.125rem;
           padding: 0 12rem 0 0;
         }
@@ -116,7 +117,7 @@
         font-size: 1.25rem;
         color: $v3-color_green-dark;
         
-        @include media($break_small) {
+        @include media($break_xlarge) {
           padding: 0 1.85rem 1rem 0;
           font-size: .9375rem;
         }
@@ -136,7 +137,7 @@
         color: $v3-color_green-medium;
         background-color: $v3-color_green-lightest;
         
-        @include media($break_small) {
+        @include media($break_xlarge) {
           margin: 0;
           padding: .7rem 3.5rem .7rem 2.5rem;
         }


### PR DESCRIPTION
# Resolves #262 
Resolves issues based on this recent feedback:
1. Add padding to About Section logo. XD had 154 padding-top and bottom
2. More padding needed on mobile text only version
3. About Section is titled "Logo of the Metropolitan Area Planning Council" should be "MetroCommon Logo"?

# Why is this change necessary?
Recent feedback requires these changes.

# How does it address the issue?
About section is now formatted with CSS grid and matches XD document.
Mobile size is formatted with CSS grid and matches XD document.
Changed media breakpoints for About section from xsmall to small to provide smoother transition from full desktop screen width, to mobile screen width.

# What side effects does it have?
None