### PR TITLE
Bjs/260 custom home page hero for mobile

### DIFF
--- a/app/assets/stylesheets/components/styled-box.scss
+++ b/app/assets/stylesheets/components/styled-box.scss
@@ -13,7 +13,7 @@
     background-position: center center;
     cursor: pointer;
     overflow: hidden;
-
+ 
     &:before {
         @extend ._pseudo;
 
@@ -93,33 +93,38 @@
 
     &--extended {
       background-size: cover;
-
-        #{$self}__content {
-            margin: 0 auto;
-            padding: 10% 0 20%;
-
-            text-align: left;
-
-            p {
-                width: 51%;
-
-                &.sub-header {
-                    margin: 0;
-
-                    font-size: $font_size-large;
-                    font-style: italic;
+      
+      #{$self}__content {
+          margin: 0 auto;
+          padding: 10% 0 20%;
+          
+          text-align: left;
+          
+          p {
+              width: 51%;
+              
+              &.sub-header {
+                  margin: 0;
+                  
+                  font-size: $font_size-large;
+                  font-style: italic;
                 }
             }
         }
-
+        
         &:before {
             bottom: 98%;
             right: -10%;
-
+            
             background: $v3-color_green-medium;
             opacity: .75;
-
             transform: rotate(-28deg);
+            
+            @include media($break_large){
+                transform: rotate(-90deg);
+                bottom: 100%;
+                right: 0;
+            }
         }
     }
 }

--- a/app/assets/stylesheets/components/styled-box.scss
+++ b/app/assets/stylesheets/components/styled-box.scss
@@ -13,7 +13,6 @@
     background-position: center center;
     cursor: pointer;
     overflow: hidden;
- 
     &:before {
         @extend ._pseudo;
 

--- a/app/assets/stylesheets/partials/_one_box.scss
+++ b/app/assets/stylesheets/partials/_one_box.scss
@@ -1,3 +1,3 @@
 .one-box {
-  // height: 100%;
+  height: 100%;
 }

--- a/app/assets/stylesheets/partials/_one_box.scss
+++ b/app/assets/stylesheets/partials/_one_box.scss
@@ -1,3 +1,3 @@
 .one-box {
-  height: 100%;
+  // height: 100%;
 }

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -2,7 +2,7 @@
   background-color: $v3-color_green-lightest;
 
   .hero-banner {
-    z-index: 1;
+    // z-index: 1;
 
     &__arrow {
       $triangle_size: 42px;
@@ -45,6 +45,60 @@
           text-decoration: none;
 
           + * { margin-left: .8rem; }
+        }
+      }
+          
+      @media (max-width: 1300px){
+        &__content {
+          display: grid;
+          grid-template-columns: 348px;
+          grid-template-rows: 65px auto auto auto auto;
+          margin: 0;
+          background-image: none;
+    
+          h1 {
+            grid-column-start: 1;
+            margin: 0;
+          }
+
+          .sub-header {
+            grid-column-start: 1;
+            font-size: 17px;
+            font-display: italic;
+            width: 236px;
+          }
+
+          p {
+            grid-column-start: 1;
+            font-size: 16px;
+            width: 345px;
+          }
+          
+          // .hero-banner {
+          //   visibility: hidden;
+          //   background: none;
+          // }
+
+          .hero-banner-actions {
+            grid-column-start: 1;
+            margin: 0;
+          }
+
+          a.button {
+            height: 45px;
+            margin-bottom: 1rem;
+            width: 100%;
+            padding-top: .7rem;
+          }
+          
+          button.button {
+            height: 45px;
+            border: 3px solid $v3-color_green-light;
+            // padding: 1rem 0;
+            padding: 0;
+            margin: 0 0 1rem 0;
+            width: 100%;
+          }
         }
       }
     }
@@ -110,7 +164,6 @@
           margin-bottom: 0.5rem;
         }
       }
-
 
       &-title {
         font-family: $font_family-primary;

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -2,7 +2,7 @@
   background-color: $v3-color_green-lightest;
 
   .hero-banner {
-    // z-index: 1;
+    z-index: 1;
 
     &__arrow {
       $triangle_size: 42px;
@@ -73,12 +73,7 @@
             font-size: 16px;
             width: 345px;
           }
-          
-          // .hero-banner {
-          //   visibility: hidden;
-          //   background: none;
-          // }
-
+     
           .hero-banner-actions {
             grid-column-start: 1;
             margin: 0;
@@ -98,6 +93,23 @@
             padding: 0;
             margin: 0 0 1rem 0;
             width: 100%;
+          }
+
+          .styled-box {
+            $self: &;
+            $trans_duration: .25s;
+            $content_trans: transform $trans_duration;
+            $title_trans: opacity $trans_duration, top ($trans_duration * 1.2);
+        
+            padding: 1rem;
+        
+            color: $color_font-light;
+        
+            background: $v3-color_green-lightest;
+            background-size: 101%;
+            background-position: center center;
+            cursor: pointer;
+            overflow: hidden;
           }
         }
       }

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -47,7 +47,7 @@
           + * { margin-left: .8rem; }
         }
       }
-          
+      
       @media (max-width: 1300px){
         &__content {
           display: grid;
@@ -93,23 +93,6 @@
             padding: 0;
             margin: 0 0 1rem 0;
             width: 100%;
-          }
-
-          .styled-box {
-            $self: &;
-            $trans_duration: .25s;
-            $content_trans: transform $trans_duration;
-            $title_trans: opacity $trans_duration, top ($trans_duration * 1.2);
-        
-            padding: 1rem;
-        
-            color: $color_font-light;
-        
-            background: $v3-color_green-lightest;
-            background-size: 101%;
-            background-position: center center;
-            cursor: pointer;
-            overflow: hidden;
           }
         }
       }

--- a/app/javascript/packs/hero-rotation.js
+++ b/app/javascript/packs/hero-rotation.js
@@ -1,5 +1,7 @@
 $(() => {
-  getImages()
+  if (checkWidth()) {
+    getImages()
+  }
 });
 
 let counter = 0
@@ -10,6 +12,10 @@ if (baseUrl.match(/\/$/)) {
   baseUrl = baseUrl.replace(/\/$/i, "")
 } if (baseUrl.match(/\/..?$/i)) {
   baseUrl = baseUrl.replace(/\/..?$/i, "")
+}
+
+const checkWidth = () => {
+  return document.documentElement.clientWidth > 1300
 }
 
 const getImages = () => {
@@ -42,7 +48,7 @@ const loadImage = (img) => {
   counter -= 1
   let hero = $('.styled-box')[0];
 
-  if (img) {
+  if (img && checkWidth()) {
     let imgUrl = `${baseUrl}${img.included[0].attributes.hero_image_thumbnail_url}`
     hero.style.backgroundImage = `url(${imgUrl})`
     hero.classList.add('rotation-test')
@@ -57,5 +63,7 @@ const loadImage = (img) => {
 
 const replay = () => {
   counter = imagesList.length
-  loadImages(imagesList)
+  if (checkWidth()) {
+    loadImages(imagesList)
+  }
 };

--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -12,7 +12,7 @@
 
           <p class="sub-header">
             Greater Boston's next regional plan <br>
-            Led by the Metropolitan Area Planning Council
+            Led by the Metropolitan Area Planning Council (MAPC)
           </p>
 
           <p>

--- a/spec/system/hero_rotation_spec.rb
+++ b/spec/system/hero_rotation_spec.rb
@@ -4,8 +4,7 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "has a different hero section background image, 5 seconds after pageload, if 1 hero image is created", js: true do
     create(:page)
     hero_image = create(:hero_image)
-    window = Capybara.current_session.driver.browser.manage.window
-    window.resize_to(1440, 1000) # width, height    
+    Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -14,8 +13,7 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with English language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
-    window = Capybara.current_session.driver.browser.manage.window
-    window.resize_to(1440, 1000) # width, height    
+    Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/en/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -24,8 +22,7 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with Portugese language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
-    window = Capybara.current_session.driver.browser.manage.window
-    window.resize_to(1440, 1000) # width, height    
+    Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/pt/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -34,8 +31,7 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with Spanish language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
-    window = Capybara.current_session.driver.browser.manage.window
-    window.resize_to(1440, 1000) # width, height    
+    Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/es/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -44,21 +40,17 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with Chinese language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
-    window = Capybara.current_session.driver.browser.manage.window
-    window.resize_to(1440, 1000) # width, height    
+    Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/zh/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
   end
-
+  
   it "works with French language selected", js: true do
     create(:page)
-    hero_image1 = create(:hero_image)
-    hero_image2 = create(:hero_image)
-    hero_image3 = create(:hero_image)
-    window = Capybara.current_session.driver.browser.manage.window
-    window.resize_to(1440, 1000) # width, height    
+    hero_image = create(:hero_image)  
+    Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/fr/"
-    expect(page.has_selector?('.rotation-test')).to be(true)
+    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
   end
 end

--- a/spec/system/hero_rotation_spec.rb
+++ b/spec/system/hero_rotation_spec.rb
@@ -3,54 +3,54 @@ require "rails_helper"
 RSpec.describe "Hero image rotation", :type => :system do
   it "has a different hero section background image, 5 seconds after pageload, if 1 hero image is created", js: true do
     create(:page)
-    hero_image = create(:hero_image)
+    create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
+    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
   end
 
   it "works with English language selected", js: true do
     create(:page)
-    hero_image = create(:hero_image)
+    create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/en/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
+    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
   end
 
   it "works with Portugese language selected", js: true do
     create(:page)
-    hero_image = create(:hero_image)
+    create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/pt/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
+    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
   end
 
   it "works with Spanish language selected", js: true do
     create(:page)
-    hero_image = create(:hero_image)
+    create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/es/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
+    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
   end
 
   it "works with Chinese language selected", js: true do
     create(:page)
-    hero_image = create(:hero_image)
+    create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/zh/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
+    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
   end
-  
+
   it "works with French language selected", js: true do
     create(:page)
-    hero_image = create(:hero_image)  
+    create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/fr/"
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
+    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
   end
 end

--- a/spec/system/hero_rotation_spec.rb
+++ b/spec/system/hero_rotation_spec.rb
@@ -4,6 +4,8 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "has a different hero section background image, 5 seconds after pageload, if 1 hero image is created", js: true do
     create(:page)
     hero_image = create(:hero_image)
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(1440, 1000) # width, height    
     visit "/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -12,6 +14,8 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with English language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(1440, 1000) # width, height    
     visit "/en/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -20,6 +24,8 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with Portugese language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(1440, 1000) # width, height    
     visit "/pt/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -28,6 +34,8 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with Spanish language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(1440, 1000) # width, height    
     visit "/es/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -36,6 +44,8 @@ RSpec.describe "Hero image rotation", :type => :system do
   it "works with Chinese language selected", js: true do
     create(:page)
     hero_image = create(:hero_image)
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(1440, 1000) # width, height    
     visit "/zh/"
     sleep 3
     expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
@@ -43,9 +53,12 @@ RSpec.describe "Hero image rotation", :type => :system do
 
   it "works with French language selected", js: true do
     create(:page)
-    hero_image = create(:hero_image)
+    hero_image1 = create(:hero_image)
+    hero_image2 = create(:hero_image)
+    hero_image3 = create(:hero_image)
+    window = Capybara.current_session.driver.browser.manage.window
+    window.resize_to(1440, 1000) # width, height    
     visit "/fr/"
-    sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach.jpeg\");")).to be(true)
+    expect(page.has_selector?('.rotation-test')).to be(true)
   end
 end

--- a/vendor/extensions/hero_images/spec/support/factories/refinery/hero_images.rb
+++ b/vendor/extensions/hero_images/spec/support/factories/refinery/hero_images.rb
@@ -3,5 +3,6 @@ FactoryBot.define do
     sequence(:title) { |n| "HeroImage#{n}" }
     description { "This describes the hero image." }
     image
+    # association :image, factory: :alternate_image
   end
 end


### PR DESCRIPTION
Resolves #260

# Why is this change necessary?
This is needed to provide mobile view of hero section.

# How does it address the issue?
It resizes and places the buttons upon the 'large' break point.
The green overlay covers the hero instead of being a triangle.
The rotating hero images stop at the break point.

# What side effects does it have?
None.