### PR TITLE
Mjz/240 one box admin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -89,3 +89,4 @@ gem 'refinerycms-stories', path: 'vendor/extensions'
 gem 'refinerycms-announcements', path: 'vendor/extensions'
 
 gem 'refinerycms-hero_images', path: 'vendor/extensions'
+gem 'refinerycms-one_boxes', path: 'vendor/extensions'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,9 @@ PATH
     refinerycms-hero_images (1.0)
       acts_as_indexed (~> 0.8.0)
       refinerycms-core (~> 4.0.2)
+    refinerycms-one_boxes (1.0)
+      acts_as_indexed (~> 0.8.0)
+      refinerycms-core (~> 4.0.2)
     refinerycms-stories (1.0)
       acts_as_indexed (~> 0.8.0)
       refinerycms-core (~> 4.0.2)
@@ -632,6 +635,7 @@ DEPENDENCIES
   refinerycms-events!
   refinerycms-hero_images!
   refinerycms-i18n
+  refinerycms-one_boxes!
   refinerycms-search!
   refinerycms-stories!
   refinerycms-wymeditor (~> 2.0, >= 2.0.0)

--- a/Guardfile
+++ b/Guardfile
@@ -53,3 +53,57 @@ guard 'livereload' do
   watch(%r{app/helpers/.+\.rb})
   watch(%r{config/locales/.+\.yml})
 end
+
+# Note: The cmd option is now required due to the increasing number of ways
+#       rspec may be run, below are examples of the most common uses.
+#  * bundler: 'bundle exec rspec'
+#  * bundler binstubs: 'bin/rspec'
+#  * spring: 'bin/rspec' (This will use spring if running and you have
+#                          installed the spring binstubs per the docs)
+#  * zeus: 'zeus rspec' (requires the server to be started separately)
+#  * 'just' rspec: 'rspec'
+
+guard :rspec, cmd: "bundle exec rspec" do
+  require "guard/rspec/dsl"
+  dsl = Guard::RSpec::Dsl.new(self)
+
+  # Feel free to open issues for suggestions and improvements
+
+  # RSpec files
+  rspec = dsl.rspec
+  watch(rspec.spec_helper) { rspec.spec_dir }
+  watch(rspec.spec_support) { rspec.spec_dir }
+  watch(rspec.spec_files)
+
+  # Ruby files
+  ruby = dsl.ruby
+  dsl.watch_spec_files_for(ruby.lib_files)
+
+  # Rails files
+  rails = dsl.rails(view_extensions: %w(erb haml slim))
+  dsl.watch_spec_files_for(rails.app_files)
+  dsl.watch_spec_files_for(rails.views)
+
+  watch(rails.controllers) do |m|
+    [
+      rspec.spec.call("routing/#{m[1]}_routing"),
+      rspec.spec.call("controllers/#{m[1]}_controller"),
+      rspec.spec.call("acceptance/#{m[1]}")
+    ]
+  end
+
+  # Rails config changes
+  watch(rails.spec_helper)     { rspec.spec_dir }
+  watch(rails.routes)          { "#{rspec.spec_dir}/routing" }
+  watch(rails.app_controller)  { "#{rspec.spec_dir}/controllers" }
+
+  # Capybara features specs
+  watch(rails.view_dirs)     { |m| rspec.spec.call("features/#{m[1]}") }
+  watch(rails.layouts)       { |m| rspec.spec.call("features/#{m[1]}") }
+
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$}) do |m|
+    Dir[File.join("**/#{m[1]}.feature")][0] || "spec/acceptance"
+  end
+end

--- a/app/decorators/controllers/refinery/pages_controller_decorator.rb
+++ b/app/decorators/controllers/refinery/pages_controller_decorator.rb
@@ -1,13 +1,16 @@
 Refinery::PagesController.class_eval do
-
-  before_action :find_next_events, :only => [:home]
+  before_action :find_next_events, only: [:home]
+  before_action :one_boxes, only: [:home]
 
   protected
 
-    def find_next_events
-      now = DateTime.now
-      now_nozone = DateTime.new(now.year, now.month, now.day, now.hour, now.minute, now.second)
-      @next_events = ::Refinery::Events::Event.where("start > ?", now_nozone).order('start ASC')
-    end
+  def one_boxes
+    @one_boxes = ::Refinery::OneBoxes::OneBox.order(:position).all
+  end
 
+  def find_next_events
+    now = DateTime.now
+    now_nozone = DateTime.new(now.year, now.month, now.day, now.hour, now.minute, now.second)
+    @next_events = ::Refinery::Events::Event.where("start > ?", now_nozone).order('start ASC')
+  end
 end

--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -41,41 +41,14 @@
   <%= render "partials/announcements" %>
 
   <section class="one-box-grid grid grid--3-2">
-    <div class="grid__cell">
-      <a href="">
-        <%= render partial: '/partials/one_box', locals: { type: 'half', title: 'FIND OUT', image: 'find-out.jpg' } %>
-      </a>
-    </div>
-
-    <div class="grid__cell">
-      <a href="">
-        <%= render partial: '/partials/one_box', locals: { type: 'half', title: 'WEIGH IN', image: 'weigh-in.jpg' } %>
-      </a>
-    </div>
-
-    <div class="grid__cell">
-      <a href="">
-        <%= render partial: '/partials/one_box', locals: { type: 'half', title: 'PROCESS DETAILS', image: 'process-timeline.jpg' } %>
-      </a>
-    </div>
-
-    <div class="grid__cell">
-      <a href="">
-        <%= render partial: '/partials/one_box', locals: { type: 'half', title: 'VOICES FROM THE REGION', image: 'voices.jpg' } %>
-      </a>
-    </div>
-
-    <div class="grid__cell">
-      <a href="">
-        <%= render partial: '/partials/one_box', locals: { type: 'half', title: 'PROCESS DETAILS', image: 'process-details.jpg' } %>
-      </a>
-    </div>
-
-    <div class="grid__cell">
-      <a href="">
-        <%= render partial: '/partials/event_box', locals: { events: @next_events } %>
-      </a>
-    </div>
+    <% @one_boxes.each do |box| %>
+      <% next unless box.visible %>
+      <div class="grid__cell">
+        <%= link_to box.link do %>
+          <%= render partial: '/partials/one_box', locals: { type: box.triangle_overlay ? 'half' : nil, title: box.title, image: box.image.thumbnail(geometry: :one_box).url } %>
+        <% end %>
+      </div>
+    <% end %>
   </section>
 
   <section class="regional-plan">

--- a/config/initializers/refinery/images.rb
+++ b/config/initializers/refinery/images.rb
@@ -17,7 +17,7 @@ Refinery::Images.configure do |config|
   # config.pages_per_admin_index = 20
 
   # Configure image sizes
-  config.user_image_sizes = {:small=>"110x110>", :medium=>"225x255>", :large=>"450x450>", :carousel=>"992x600>", :carousel2x=>"1984x1200>", :hero_image=>"1920x1010>", :hero_image2x=>"3840x2020>"}
+  config.user_image_sizes = { :small=>"110x110>", :medium=>"225x255>", :large=>"450x450>", :carousel=>"992x600>", :carousel2x=>"1984x1200>", :hero_image=>"1920x1010>", :hero_image2x=>"3840x2020>", :one_box=>"421x421>" }
 
   # Configure image ratios
   # config.user_image_ratios = {:"16/9"=>"1.778", :"4/3"=>"1.333", :"1:1"=>1}

--- a/db/migrate/20190402144017_create_one_boxes_one_boxes.refinery_one_boxes.rb
+++ b/db/migrate/20190402144017_create_one_boxes_one_boxes.refinery_one_boxes.rb
@@ -1,0 +1,39 @@
+# This migration comes from refinery_one_boxes (originally 1)
+class CreateOneBoxesOneBoxes < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :refinery_one_boxes do |t|
+      t.boolean :visible
+      t.boolean :triangle_overlay
+      t.integer :image_id
+      t.string :link
+      t.integer :position
+
+      t.timestamps
+    end
+
+
+    create_table :refinery_one_box_translations do |t|
+      t.string :title
+      t.string  :locale, null: false
+      t.integer :refinery_one_box_id, null: false
+      t.timestamps
+    end
+
+    add_index :refinery_one_box_translations, :locale, name: :index_refinery_one_box_translations_on_locale
+    add_index :refinery_one_box_translations, [:refinery_one_box_id, :locale], name: :index_95394ba315aed2cb69dea96439990984a765aa44, unique: true
+
+  end
+
+
+  def down
+    if defined?(::Refinery::UserPlugin)
+      ::Refinery::UserPlugin.destroy_all({:name => "refinerycms-one_boxes"})
+    end
+
+    drop_table :refinery_one_boxes
+
+    drop_table :refinery_one_box_translations
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_26_203306) do
+ActiveRecord::Schema.define(version: 2019_04_02_144017) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -169,6 +169,26 @@ ActiveRecord::Schema.define(version: 2019_03_26_203306) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer "parent_id"
+  end
+
+  create_table "refinery_one_box_translations", force: :cascade do |t|
+    t.string "title"
+    t.string "locale", null: false
+    t.integer "refinery_one_box_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["locale"], name: "index_refinery_one_box_translations_on_locale"
+    t.index ["refinery_one_box_id", "locale"], name: "index_95394ba315aed2cb69dea96439990984a765aa44", unique: true
+  end
+
+  create_table "refinery_one_boxes", force: :cascade do |t|
+    t.boolean "visible"
+    t.boolean "triangle_overlay"
+    t.integer "image_id"
+    t.string "link"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "refinery_page_part_translations", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -27,3 +27,6 @@ Refinery::Announcements::Engine.load_seed
 
 # Added by Refinery CMS HeroImages extension
 Refinery::HeroImages::Engine.load_seed
+
+# Added by Refinery CMS OneBoxes extension
+Refinery::OneBoxes::Engine.load_seed

--- a/spec/system/one_box_spec.rb
+++ b/spec/system/one_box_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "One boxes", :type => :system do
+  it "displays a box for each one box" do
+    create(:page)
+    one_box = create(:one_box)
+    visit "/"
+    expect(page).to have_content(one_box.title)
+  end
+
+  it "displays the boxes in order" do
+    create(:page)
+    one_box2 = create(:one_box, position: 2)
+    one_box1 = create(:one_box, position: 1)
+    visit "/"
+    expect(all('.styled-box__title')[0]&.text).to have_text(one_box1.title)
+    expect(all('.styled-box__title')[1]&.text).to have_text(one_box2.title)
+  end
+
+  it "does not display hidden boxes" do
+    create(:page)
+    one_box1 = create(:one_box, visible: false)
+    visit "/"
+    expect(all('.styled-box__title')[0]&.text).not_to have_text(one_box1.title)
+  end
+end

--- a/vendor/extensions/one_boxes/Gemfile
+++ b/vendor/extensions/one_boxes/Gemfile
@@ -1,0 +1,43 @@
+source "https://rubygems.org"
+
+gemspec
+
+git 'https://github.com/refinery/refinerycms.git', :branch => 'master' do
+  gem 'refinerycms'
+
+  group :development, :test do
+    gem 'refinerycms-testing'
+  end
+end
+
+# Database Configuration
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'activerecord-jdbcmysql-adapter'
+  gem 'activerecord-jdbcpostgresql-adapter'
+  gem 'jruby-openssl'
+end
+
+platforms :ruby do
+  gem 'sqlite3'
+  gem 'mysql2', '~> 0.4.10'
+  gem 'pg'
+end
+
+group :development, :test do
+  gem 'rspec-its' # for the model's validation tests.
+  platforms :ruby do
+    require 'rbconfig'
+    if RbConfig::CONFIG['target_os'] =~ /linux/i
+      gem 'therubyracer', '~> 0.11.4'
+    end
+  end
+end
+
+# Gems used only for assets and not required
+# in production environments by default.
+group :assets do
+  gem 'sass-rails'
+  gem 'coffee-rails'
+  gem 'uglifier'
+end

--- a/vendor/extensions/one_boxes/Rakefile
+++ b/vendor/extensions/one_boxes/Rakefile
@@ -1,0 +1,19 @@
+#!/usr/bin/env rake
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+ENGINE_PATH = File.dirname(__FILE__)
+APP_RAKEFILE = File.expand_path "../spec/dummy/Rakefile", __FILE__
+
+if File.exists? APP_RAKEFILE
+  load 'rails/tasks/engine.rake'
+end
+
+require "refinerycms-testing"
+Refinery::Testing::Railtie.load_dummy_tasks ENGINE_PATH
+
+load File.expand_path('../tasks/testing.rake', __FILE__)
+load File.expand_path('../tasks/rspec.rake', __FILE__)

--- a/vendor/extensions/one_boxes/app/controllers/refinery/one_boxes/admin/one_boxes_controller.rb
+++ b/vendor/extensions/one_boxes/app/controllers/refinery/one_boxes/admin/one_boxes_controller.rb
@@ -1,0 +1,17 @@
+module Refinery
+  module OneBoxes
+    module Admin
+      class OneBoxesController < ::Refinery::AdminController
+
+        crudify :'refinery/one_boxes/one_box'
+
+        private
+
+        # Only allow a trusted parameter "white list" through.
+        def one_box_params
+          params.require(:one_box).permit(:title, :visible, :triangle_overlay, :image_id, :link)
+        end
+      end
+    end
+  end
+end

--- a/vendor/extensions/one_boxes/app/models/refinery/one_boxes/one_box.rb
+++ b/vendor/extensions/one_boxes/app/models/refinery/one_boxes/one_box.rb
@@ -1,0 +1,20 @@
+module Refinery
+  module OneBoxes
+    class OneBox < Refinery::Core::BaseModel
+      self.table_name = 'refinery_one_boxes'
+
+
+      extend Mobility
+      translates :title
+
+      validates :title, :presence => true, :uniqueness => true
+
+      belongs_to :image, :class_name => '::Refinery::Image'
+
+      # To enable admin searching, add acts_as_indexed on searchable fields, for example:
+      #
+      #   acts_as_indexed :fields => [:title]
+
+    end
+  end
+end

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_actions.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_actions.html.erb
@@ -1,0 +1,20 @@
+<ul>
+  <% if ::Refinery::OneBoxes::Admin::OneBoxesController.searchable? %>
+    <li>
+      <%= render '/refinery/admin/search', :url => refinery.one_boxes_admin_one_boxes_path %>
+    </li>
+  <% end %>
+  <li>
+    <%= action_label :add, refinery.new_one_boxes_admin_one_box_path, t('.create_new') %>
+  </li>
+<% if !searching? && ::Refinery::OneBoxes::Admin::OneBoxesController.sortable? && ::Refinery::OneBoxes::OneBox.many? %>
+  <li>
+    <%= action_label :reorder,
+                     refinery.one_boxes_admin_one_boxes_path,
+                     t('.reorder', what:  "One Boxes"), id: 'reorder_action'%>
+    <%= action_label :reorder_done,
+                     refinery.one_boxes_admin_one_boxes_path,
+                      t('.reorder_done', what: "One Boxes"), id: 'reorder_action_done', class: 'hidden'%>
+  </li>
+<% end %>
+</ul>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_form.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_form.html.erb
@@ -1,0 +1,42 @@
+<%= form_for [refinery, :one_boxes_admin, @one_box] do |f| -%>
+  <%= render '/refinery/admin/error_messages',
+              :object => @one_box,
+              :include_object_name => true %>
+
+  <%= render '/refinery/admin/locale_picker',
+              :current_locale => Mobility.locale %>
+  <div class='field'>
+    <%= f.label :title -%>
+    <%= f.text_field :title, :class => 'larger widest' -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :visible -%>
+    <%= f.check_box :visible, :checked => @one_box[:visible] -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :triangle_overlay -%>
+    <%= f.check_box :triangle_overlay, :checked => @one_box[:triangle_overlay] -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :image -%>
+    <%= render '/refinery/admin/image_picker',
+               :f => f,
+               :field => :image_id,
+               :image => @one_box.image,
+               :toggle_image_display => false -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :link -%>
+    <%= f.text_field :link -%>
+  </div>
+
+  <%= render '/refinery/admin/form_actions', f: f,
+             continue_editing: false,
+             delete_title: t('delete', scope: 'refinery.one_boxes.admin.one_boxes.one_box'),
+             delete_confirmation: t('message', scope: 'refinery.admin.delete', title: @one_box.title),
+             cancel_url: refinery.one_boxes_admin_one_boxes_path -%>
+<% end -%>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_one_box.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_one_box.html.erb
@@ -1,0 +1,31 @@
+<li class='clearfix record <%= cycle("on", "on-hover") %>' id="<%= dom_id(one_box) -%>">
+  <span class='title'>
+    <%= translated_field(one_box, :title) %>
+  </span>
+
+  <% if Refinery::I18n.frontend_locales.many? %>
+    <span class='locales'>
+      <% one_box.translations.sort_by{ |t| Refinery::I18n.frontend_locales.index(t.locale)}.each do |translation| %>
+        <% if translation.title.present? %>
+          <%= link_to refinery.edit_one_boxes_admin_one_box_path(one_box, :switch_locale => translation.locale),
+                      class: 'locale', title: translation.locale.upcase do %>
+
+            <div class="<%=translation.locale %> locale_marker">
+              <%= locale_text_icon(translation.locale.upcase) %>
+            </div>
+          <% end %>
+        <% end %>
+      <% end %>
+    </span>
+  <% end %>
+
+  <span class='preview'></span>
+
+  <span class='actions'>
+    
+    <%= action_icon(:edit,    refinery.edit_one_boxes_admin_one_box_path(one_box), t('.edit') ) %>
+    <%= action_icon(:delete,  refinery.one_boxes_admin_one_box_path(one_box), t('.delete'),
+      { class: "cancel confirm-delete",
+        data: {confirm: t('message',  scope: 'refinery.admin.delete', title: one_box.title)}}  ) %>
+  </span>
+</li>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_one_boxes.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_one_boxes.html.erb
@@ -1,0 +1,2 @@
+<%= will_paginate @one_boxes if Refinery::OneBoxes::Admin::OneBoxesController.pageable? %>
+<%= render 'sortable_list' %>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_records.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_records.html.erb
@@ -1,0 +1,16 @@
+<%= render 'refinery/admin/search_header', :url => refinery.one_boxes_admin_one_boxes_path %>
+<div class='pagination_container'>
+  <% if @one_boxes.any? %>
+    <%= render 'one_boxes' %>
+  <% else %>
+    <p>
+      <% if searching? %>
+        <%= t('no_results', :scope => 'refinery.admin.search') %>
+      <% else %>
+        <strong>
+          <%= t('.no_items_yet') %>
+        </strong>
+      <% end %>
+    </p>
+  <% end %>
+</div>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_sortable_list.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/_sortable_list.html.erb
@@ -1,0 +1,5 @@
+<ul id='sortable_list'>
+  <%= render :partial => 'one_box', :collection => @one_boxes %>
+</ul>
+<%= render '/refinery/admin/sortable_list',
+            :continue_reordering => (local_assigns.keys.include?(:continue_reordering)) ? continue_reordering : true %>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/edit.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/index.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/index.html.erb
@@ -1,0 +1,7 @@
+<section id='records'>
+  <%= render 'records' %>
+</section>
+<aside id='actions'>
+  <%= render 'actions' %>
+</aside>
+<%= render '/refinery/admin/make_sortable', options: {tree: false} if !searching? and ::Refinery::OneBoxes::Admin::OneBoxesController.sortable? and ::Refinery::OneBoxes::OneBox.many? %>

--- a/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/new.html.erb
+++ b/vendor/extensions/one_boxes/app/views/refinery/one_boxes/admin/one_boxes/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/vendor/extensions/one_boxes/config/locales/cs.yml
+++ b/vendor/extensions/one_boxes/config/locales/cs.yml
@@ -1,0 +1,31 @@
+cs:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Přidat One Box
+            reorder: Řadit One Boxes
+            reorder_done: Konec řazení One Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: Litujeme, ale nebyly nalezny žádné výsledky.
+            no_items_yet: Zatím nebyly vytvořeny žádné One Boxes. Zvolte "Přidat One Box" pro přidání prvního one box.
+          one_box:
+            view_live_html: Zobrazit náhled one box<br/><em>(otevře se v novém okně)</em>
+            edit: Upravit one box
+            delete: Smazat one box
+      one_boxes:
+        show:
+          other: Další One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/en.yml
+++ b/vendor/extensions/one_boxes/config/locales/en.yml
@@ -1,0 +1,31 @@
+en:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Add New One Box
+            reorder: Reorder One Boxes
+            reorder_done: Done Reordering One Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: Sorry! There are no results found.
+            no_items_yet: There are no One Boxes yet. Click "Add New One Box" to add your first one box.
+          one_box:
+            view_live_html: View this one box live <br/><em>(opens in a new window)</em>
+            edit: Edit this one box
+            delete: Remove this one box forever
+      one_boxes:
+        show:
+          other: Other One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/es.yml
+++ b/vendor/extensions/one_boxes/config/locales/es.yml
@@ -1,0 +1,32 @@
+es:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+#        article: masculino/femenino
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Crear nuevo one box
+            reorder: Reordenar one boxes
+            reorder_done: Reordenación de one boxes completada
+          records:
+            title: One Boxes
+            sorry_no_results: Lo siento, no hay resultados
+            no_items_yet: No hay one boxes todavía. Pulsa en "Crear nuevo One Box" para crear tu primer one box.
+          one_box:
+            view_live_html: Ver este one box como abierto al público <br/><em>(abre en ventana nueva)</em>
+            edit: Editar este one box
+            delete: Borrar este one box para siempre
+      one_boxes:
+        show:
+          other: Otros one boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/fr.yml
+++ b/vendor/extensions/one_boxes/config/locales/fr.yml
@@ -1,0 +1,31 @@
+fr:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Créer un(e) nouve(au/l/lle) One Box
+            reorder: Réordonner les One Boxes
+            reorder_done: Fin de réordonnancement des One Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: "Désolé ! Aucun résultat."
+            no_items_yet: 'Il n''y a actuellement aucun(e) One Box. Cliquer sur "Créer un(e) nouve(au/l/lle) One Box" pour créer votre premi(er/ère) one box.'
+          one_box:
+            view_live_html: Voir ce(t/tte) one box <br/><em>(Ouvre une nouvelle fenêtre)</em>
+            edit: Modifier ce(t/tte) one box
+            delete: Supprimer définitivement ce(t/tte) one box
+      one_boxes:
+        show:
+          other: Autres One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/it.yml
+++ b/vendor/extensions/one_boxes/config/locales/it.yml
@@ -1,0 +1,31 @@
+it:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Aggiungi Nuovo One Box
+            reorder: Riordina One Boxes
+            reorder_done: Termina il Riordino di One Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: "Spiacenti! Nessun risultato trovato"
+            no_items_yet: Non ci sono ancora One Boxes. Clicca "Aggiungi Nuovo One Box" per aggiungere il tuo primo one box.
+          one_box:
+            view_live_html: Guarda live questo one box <br/><em>(apre una nuova finestra)</em>
+            edit: Modifica questo one box
+            delete: Rimuovi per sempre questo one box
+      one_boxes:
+        show:
+          other: Altri One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/nb.yml
+++ b/vendor/extensions/one_boxes/config/locales/nb.yml
@@ -1,0 +1,31 @@
+nb:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Lag en ny One Box
+            reorder: Endre rekkefølgen på One Boxes
+            reorder_done: Ferdig å endre rekkefølgen One Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: Beklager! Vi fant ikke noen resultater.
+            no_items_yet: Det er ingen One Boxes enda. Klikk på "Lag en ny One Box" for å legge til din første one box.
+          one_box:
+            view_live_html: Vis hvordan denne one box ser ut offentlig <br/><em>(åpner i et nytt vindu)</em>
+            edit: Rediger denne one box
+            delete: Fjern denne one box permanent
+      one_boxes:
+        show:
+          other: Andre One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/nl.yml
+++ b/vendor/extensions/one_boxes/config/locales/nl.yml
@@ -1,0 +1,31 @@
+nl:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Nieuwe One Box toevoegen
+            reorder: De volgorde van de One Boxes wijzigen
+            reorder_done: Klaar met het wijzingen van de van de One Box-volgorde
+          records:
+            title: One Boxes
+            sorry_no_results: Helaas! Er zijn geen resultaten gevonden.
+            no_items_yet: Er zijn nog geen One Boxes. Druk op 'Nieuwe One Box toevoegen' om de eerste toe te voegen.
+          one_box:
+            view_live_html: Deze one box op de website bekijken <br/><em>(opent in een nieuw venster)</em>
+            edit: Bewerk deze one box
+            delete: Deze one box definitief verwijderen
+      one_boxes:
+        show:
+          other: Andere One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/ru.yml
+++ b/vendor/extensions/one_boxes/config/locales/ru.yml
@@ -1,0 +1,31 @@
+ru:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Добавить One Box
+            reorder: Изменить порядок One Boxes
+            reorder_done: Закончить изменять порядок One Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: "Извините, поиск не дал результатов."
+            no_items_yet: Записей "One Boxes" не найдено. Нажмите "Добавить One Box" чтобы создать one box.
+          one_box:
+            view_live_html: Просмотреть one box вживую <br/><em>(в новом окне)</em>
+            edit: Редактировать one box
+            delete: Удалить one box навсегда
+      one_boxes:
+        show:
+          other: Другие One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/sk.yml
+++ b/vendor/extensions/one_boxes/config/locales/sk.yml
@@ -1,0 +1,31 @@
+sk:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Pridať One Box
+            reorder: Preusporiadať One Boxes
+            reorder_done: Koniec radenia One Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: Ľutujeme, ale neboli nájdené žiadne výsledky.
+            no_items_yet: Nie sú vytvorené žiadne One Boxes. Kliknite na "Pridať One Box" pre pridanie prvého one box.
+          one_box:
+            view_live_html: Zobraziť náhľad one box<br/><em>(otvorí sa v novom okne)</em>
+            edit: Upraviť one box
+            delete: Zmazať one box
+      one_boxes:
+        show:
+          other: Daľšie One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/tr.yml
+++ b/vendor/extensions/one_boxes/config/locales/tr.yml
@@ -1,0 +1,31 @@
+tr:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: Yeni Ekle One Box
+            reorder: Tekrar sirala One Boxes
+            reorder_done: Tekrar siralama tamamlandiOne Boxes
+          records:
+            title: One Boxes
+            sorry_no_results: Uzgunum! Herhangi bir sonuc bulunamadi.
+            no_items_yet: Herhangi bir One Boxes yok henuz.  Tikla "Yeni Ekle One Box" eklemek senin ilk one box.
+          one_box:
+            view_live_html: Bunu canlu one box goruntule <br/><em>(yeni bir pencerede acar)</em>
+            edit: Bunu Duzenle one box
+            delete: Bunu Sil one box sonsuza dek
+      one_boxes:
+        show:
+          other: Diger One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/locales/zh-CN.yml
+++ b/vendor/extensions/one_boxes/config/locales/zh-CN.yml
@@ -1,0 +1,33 @@
+zh-CN:
+  refinery:
+    plugins:
+      one_boxes:
+        title: One Boxes
+    one_boxes:
+      admin:
+        one_boxes:
+          actions:
+            create_new: 建立新的 One Box
+            reorder: 对 One Boxes 重新排序
+            reorder_done: 对 One Boxes 的重新排序结束
+          records:
+            title: One Boxes
+            sorry_no_results: 对不起，未找到结果。 #Sorry! There are no results found.
+
+            # There are no One Boxes yet. Click "Add New One Box" to add your first one box.
+            no_items_yet: 目前没有 One Boxes . 点击 "Add New One Box" 创建一个one box.
+          one_box:
+            view_live_html: 查看 one box 的最新内容.<br/><em>(新窗口中打开)</em>
+            edit: 编辑 one box
+            delete: 永久删除 one box
+      one_boxes:
+        show:
+          other: 其他 One Boxes
+  activerecord:
+    attributes:
+      'refinery/one_boxes/one_box':
+        title: Title
+        visible: Visible
+        triangle_overlay: Triangle Overlay
+        image: Image
+        link: Link

--- a/vendor/extensions/one_boxes/config/routes.rb
+++ b/vendor/extensions/one_boxes/config/routes.rb
@@ -1,0 +1,14 @@
+Refinery::Core::Engine.routes.draw do
+
+  # Admin routes
+  namespace :one_boxes, :path => '' do
+    namespace :admin, :path => Refinery::Core.backend_route do
+      resources :one_boxes, :except => :show do
+        collection do
+          post :update_positions
+        end
+      end
+    end
+  end
+
+end

--- a/vendor/extensions/one_boxes/db/migrate/1_create_one_boxes_one_boxes.rb
+++ b/vendor/extensions/one_boxes/db/migrate/1_create_one_boxes_one_boxes.rb
@@ -1,0 +1,38 @@
+class CreateOneBoxesOneBoxes < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :refinery_one_boxes do |t|
+      t.boolean :visible
+      t.boolean :triangle_overlay
+      t.integer :image_id
+      t.string :link
+      t.integer :position
+
+      t.timestamps
+    end
+
+
+    create_table :refinery_one_box_translations do |t|
+      t.string :title
+      t.string  :locale, null: false
+      t.integer :refinery_one_box_id, null: false
+      t.timestamps
+    end
+
+    add_index :refinery_one_box_translations, :locale, name: :index_refinery_one_box_translations_on_locale
+    add_index :refinery_one_box_translations, [:refinery_one_box_id, :locale], name: :index_95394ba315aed2cb69dea96439990984a765aa44, unique: true
+
+  end
+
+
+  def down
+    if defined?(::Refinery::UserPlugin)
+      ::Refinery::UserPlugin.destroy_all({:name => "refinerycms-one_boxes"})
+    end
+
+    drop_table :refinery_one_boxes
+
+    drop_table :refinery_one_box_translations
+
+  end
+end

--- a/vendor/extensions/one_boxes/db/seeds.rb
+++ b/vendor/extensions/one_boxes/db/seeds.rb
@@ -1,0 +1,10 @@
+Refinery::I18n.frontend_locales.each do |lang|
+  I18n.locale = lang
+
+  Refinery::User.find_each do |user|
+    user.plugins.where(name: 'refinerycms-one_boxes').first_or_create!(
+      position: (user.plugins.maximum(:position) || -1) +1
+    )
+  end if defined?(Refinery::User)
+
+end

--- a/vendor/extensions/one_boxes/lib/generators/refinery/one_boxes_generator.rb
+++ b/vendor/extensions/one_boxes/lib/generators/refinery/one_boxes_generator.rb
@@ -1,0 +1,19 @@
+module Refinery
+  class OneBoxesGenerator < Rails::Generators::Base
+
+    def rake_db
+      rake "refinery_one_boxes:install:migrations"
+    end
+
+    def append_load_seed_data
+      create_file 'db/seeds.rb' unless File.exists?(File.join(destination_root, 'db', 'seeds.rb'))
+      append_file 'db/seeds.rb', :verbose => true do
+        <<-EOH
+
+# Added by Refinery CMS OneBoxes extension
+Refinery::OneBoxes::Engine.load_seed
+        EOH
+      end
+    end
+  end
+end

--- a/vendor/extensions/one_boxes/lib/refinery/one_boxes.rb
+++ b/vendor/extensions/one_boxes/lib/refinery/one_boxes.rb
@@ -1,0 +1,21 @@
+require 'refinerycms-core'
+
+module Refinery
+  autoload :OneBoxesGenerator, 'generators/refinery/one_boxes_generator'
+
+  module OneBoxes
+    require 'refinery/one_boxes/engine'
+
+    class << self
+      attr_writer :root
+
+      def root
+        @root ||= Pathname.new(File.expand_path('../../../', __FILE__))
+      end
+
+      def factory_paths
+        @factory_paths ||= [ root.join('spec', 'factories').to_s ]
+      end
+    end
+  end
+end

--- a/vendor/extensions/one_boxes/lib/refinery/one_boxes/engine.rb
+++ b/vendor/extensions/one_boxes/lib/refinery/one_boxes/engine.rb
@@ -1,0 +1,27 @@
+module Refinery
+  module OneBoxes
+    class Engine < Rails::Engine
+      extend Refinery::Engine
+      isolate_namespace Refinery::OneBoxes
+
+      engine_name :refinery_one_boxes
+
+      before_inclusion do
+        Refinery::Plugin.register do |plugin|
+          plugin.name = "one_boxes"
+          plugin.url = proc { Refinery::Core::Engine.routes.url_helpers.one_boxes_admin_one_boxes_path }
+          plugin.pathname = root
+
+        end
+      end
+
+      initializer "refinery_one_boxes.factories", after: "factory_bot.set_factory_paths" do
+        FactoryBot.definition_file_paths << File.expand_path('../../../../spec/support/factories/refinery', __FILE__) if defined?(FactoryBot)
+      end
+
+      config.after_initialize do
+        Refinery.register_extension(Refinery::OneBoxes)
+      end
+    end
+  end
+end

--- a/vendor/extensions/one_boxes/lib/refinerycms-one_boxes.rb
+++ b/vendor/extensions/one_boxes/lib/refinerycms-one_boxes.rb
@@ -1,0 +1,1 @@
+require 'refinery/one_boxes'

--- a/vendor/extensions/one_boxes/lib/tasks/refinery/one_boxes.rake
+++ b/vendor/extensions/one_boxes/lib/tasks/refinery/one_boxes.rake
@@ -1,0 +1,13 @@
+namespace :refinery do
+
+  namespace :one_boxes do
+
+    # call this task by running: rake refinery:one_boxes:my_task
+    # desc "Description of my task below"
+    # task :my_task => :environment do
+    #   # add your logic here
+    # end
+
+  end
+
+end

--- a/vendor/extensions/one_boxes/readme.md
+++ b/vendor/extensions/one_boxes/readme.md
@@ -1,0 +1,10 @@
+# One Boxes extension for Refinery CMS.
+
+## How to build this extension as a gem (not required)
+
+    cd vendor/extensions/one_boxes
+    gem build refinerycms-one_boxes.gemspec
+    gem install refinerycms-one_boxes.gem
+
+    # Sign up for a https://rubygems.org/ account and publish the gem
+    gem push refinerycms-one_boxes.gem

--- a/vendor/extensions/one_boxes/refinerycms-one_boxes.gemspec
+++ b/vendor/extensions/one_boxes/refinerycms-one_boxes.gemspec
@@ -1,0 +1,20 @@
+# Encoding: UTF-8
+
+Gem::Specification.new do |s|
+  s.platform          = Gem::Platform::RUBY
+  s.name              = 'refinerycms-one_boxes'
+  s.version           = '1.0'
+  s.description       = 'Ruby on Rails One Boxes extension for Refinery CMS'
+  s.date              = '2019-04-02'
+  s.summary           = 'One Boxes extension for Refinery CMS'
+  s.authors           = 
+  s.require_paths     = %w(lib)
+  s.files             = Dir["{app,config,db,lib}/**/*"] + ["readme.md"]
+
+  # Runtime dependencies
+  s.add_dependency             'refinerycms-core',    '~> 4.0.2'
+  s.add_dependency             'acts_as_indexed',     '~> 0.8.0'
+
+  # Development dependencies (usually used for testing)
+  s.add_development_dependency 'refinerycms-testing', '~> 4.0.2'
+end

--- a/vendor/extensions/one_boxes/script/rails
+++ b/vendor/extensions/one_boxes/script/rails
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+
+ENGINE_PATH = File.expand_path('../..',  __FILE__)
+dummy_rails_path = File.expand_path('../../spec/dummy/script/rails',  __FILE__)
+if File.exist?(dummy_rails_path)
+  load dummy_rails_path
+else
+  puts "Please first run 'rake refinery:testing:dummy_app' to create a dummy Refinery CMS application."
+end

--- a/vendor/extensions/one_boxes/spec/features/refinery/one_boxes/admin/one_boxes_spec.rb
+++ b/vendor/extensions/one_boxes/spec/features/refinery/one_boxes/admin/one_boxes_spec.rb
@@ -1,0 +1,197 @@
+# encoding: utf-8
+require "spec_helper"
+
+describe Refinery do
+  describe "OneBoxes" do
+    describe "Admin" do
+      describe "one_boxes", type: :feature do
+        refinery_login
+
+        describe "one_boxes list" do
+          before do
+            FactoryBot.create(:one_box, :title => "UniqueTitleOne")
+            FactoryBot.create(:one_box, :title => "UniqueTitleTwo")
+          end
+
+          it "shows two items" do
+            visit refinery.one_boxes_admin_one_boxes_path
+            expect(page).to have_content("UniqueTitleOne")
+            expect(page).to have_content("UniqueTitleTwo")
+          end
+        end
+
+        describe "create" do
+          before do
+            visit refinery.one_boxes_admin_one_boxes_path
+
+            click_link "Add New One Box"
+          end
+
+          context "valid data" do
+            it "should succeed" do
+              fill_in "Title", :with => "This is a test of the first string field"
+              expect { click_button "Save" }.to change(Refinery::OneBoxes::OneBox, :count).from(0).to(1)
+
+              expect(page).to have_content("'This is a test of the first string field' was successfully added.")
+            end
+          end
+
+          context "invalid data" do
+            it "should fail" do
+              expect { click_button "Save" }.not_to change(Refinery::OneBoxes::OneBox, :count)
+
+              expect(page).to have_content("Title can't be blank")
+            end
+          end
+
+          context "duplicate" do
+            before { FactoryBot.create(:one_box, :title => "UniqueTitle") }
+
+            it "should fail" do
+              visit refinery.one_boxes_admin_one_boxes_path
+
+              click_link "Add New One Box"
+
+              fill_in "Title", :with => "UniqueTitle"
+              expect { click_button "Save" }.not_to change(Refinery::OneBoxes::OneBox, :count)
+
+              expect(page).to have_content("There were problems")
+            end
+          end
+
+          context "with translations" do
+            before do
+              Refinery::I18n.stub(:frontend_locales).and_return([:en, :cs])
+            end
+
+            describe "add a page with title for default locale" do
+              before do
+                visit refinery.one_boxes_admin_one_boxes_path
+                click_link "Add New One Box"
+                fill_in "Title", :with => "First column"
+                click_button "Save"
+              end
+
+              it "should succeed" do
+                expect(Refinery::OneBoxes::OneBox.count).to eq(1)
+              end
+
+              it "should show locale marker for page" do
+                p = Refinery::OneBoxes::OneBox.last
+                within "#one_box_#{p.id}" do
+                  expect(page).to have_css(".locale_marker", content: 'EN')
+                end
+              end
+
+              it "should show title in the admin menu" do
+                p = Refinery::OneBoxes::OneBox.last
+                within "#one_box_#{p.id}" do
+                  expect(page).to have_content('First column')
+                end
+              end
+            end
+
+            describe "add a one_box with title for primary and secondary locale" do
+              before do
+                visit refinery.one_boxes_admin_one_boxes_path
+                click_link "Add New One Box"
+                fill_in "Title", :with => "First column"
+                click_button "Save"
+
+                visit refinery.one_boxes_admin_one_boxes_path
+                within ".actions" do
+                  click_link "Edit this one_box"
+                end
+                within "#switch_locale_picker" do
+                  click_link "Cs"
+                end
+                fill_in "Title", :with => "First translated column"
+                click_button "Save"
+              end
+
+              it "should succeed" do
+                expect(Refinery::OneBoxes::OneBox.count).to eq(1)
+                expect(Refinery::OneBoxes::OneBox::Translation.count).to eq(2)
+              end
+
+              it "should show locale flag for page" do
+                p = Refinery::OneBoxes::OneBox.last
+                within "#one_box_#{p.id}" do
+                  expect(page).to have_css(".locale_marker", content: 'EN')
+                  expect(page).to have_css(".locale_marker", content: 'CS')
+                end
+              end
+
+              it "should show title in backend locale in the admin menu" do
+                p = Refinery::OneBoxes::OneBox.last
+                within "#one_box_#{p.id}" do
+                  expect(page).to have_content('First column')
+                end
+              end
+            end
+
+            describe "add a title with title only for secondary locale" do
+              before do
+                visit refinery.one_boxes_admin_one_boxes_path
+                click_link "Add New One Box"
+                within "#switch_locale_picker" do
+                  click_link "Cs"
+                end
+
+                fill_in "Title", :with => "First translated column"
+                click_button "Save"
+              end
+
+              it "should show title in backend locale in the admin menu" do
+                p = Refinery::OneBoxes::OneBox.last
+                within "#one_box_#{p.id}" do
+                  expect(page).to have_content('First translated column')
+                end
+              end
+
+              it "should show locale flag for page" do
+                p = Refinery::OneBoxes::OneBox.last
+                within "#one_box_#{p.id}" do
+                  expect(page).to have_css(".locale_marker", content: 'CS')
+                end
+              end
+            end
+          end
+
+        end
+
+        describe "edit" do
+          before { FactoryBot.create(:one_box, :title => "A title") }
+
+          it "should succeed" do
+            visit refinery.one_boxes_admin_one_boxes_path
+
+            within ".actions" do
+              click_link "Edit this one box"
+            end
+
+            fill_in "Title", :with => "A different title"
+            click_button "Save"
+
+            expect(page).to have_content("'A different title' was successfully updated.")
+            expect(page).not_to have_content("A title")
+          end
+        end
+
+        describe "destroy" do
+          before { FactoryBot.create(:one_box, :title => "UniqueTitleOne") }
+
+          it "should succeed" do
+            visit refinery.one_boxes_admin_one_boxes_path
+
+            click_link "Remove this one box forever"
+
+            expect(page).to have_content("'UniqueTitleOne' was successfully removed.")
+            expect(Refinery::OneBoxes::OneBox.count).to eq(0)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/vendor/extensions/one_boxes/spec/models/refinery/one_boxes/one_box_spec.rb
+++ b/vendor/extensions/one_boxes/spec/models/refinery/one_boxes/one_box_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module Refinery
+  module OneBoxes
+    describe OneBox do
+      describe "validations", type: :model do
+        subject do
+          FactoryBot.create(:one_box,
+          :title => "Refinery CMS")
+        end
+
+        it { should be_valid }
+        its(:errors) { should be_empty }
+        its(:title) { should == "Refinery CMS" }
+      end
+    end
+  end
+end

--- a/vendor/extensions/one_boxes/spec/spec_helper.rb
+++ b/vendor/extensions/one_boxes/spec/spec_helper.rb
@@ -1,0 +1,30 @@
+# Configure Rails Environment
+ENV["RAILS_ENV"] ||= 'test'
+
+if File.exist?(dummy_path = File.expand_path('../dummy/config/environment.rb', __FILE__))
+  require dummy_path
+elsif File.dirname(__FILE__) =~ %r{vendor/extensions}
+  # Require the path to the refinerycms application this is vendored inside.
+  require File.expand_path('../../../../../config/environment', __FILE__)
+else
+  puts "Could not find a config/environment.rb file to require. Please specify this in #{File.expand_path(__FILE__)}"
+end
+
+require 'rspec/rails'
+require 'capybara/rspec'
+
+Rails.backtrace_cleaner.remove_silencers!
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+end
+
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories including factories.
+([Rails.root.to_s] | ::Refinery::Plugins.registered.pathnames).map{ |p|
+  Dir[File.join(p, 'spec', 'support', '**', '*.rb').to_s]
+}.flatten.sort.each do |support_file|
+  require support_file
+end

--- a/vendor/extensions/one_boxes/spec/support/factories/refinery/one_boxes.rb
+++ b/vendor/extensions/one_boxes/spec/support/factories/refinery/one_boxes.rb
@@ -1,0 +1,11 @@
+
+FactoryBot.define do
+  factory :one_box, :class => Refinery::OneBoxes::OneBox do
+    sequence(:title) { |n| "refinery#{n}" }
+    triangle_overlay { true }
+    visible { true }
+    link { "https://www.mapc.org/" }
+    image
+  end
+end
+

--- a/vendor/extensions/one_boxes/tasks/rspec.rake
+++ b/vendor/extensions/one_boxes/tasks/rspec.rake
@@ -1,0 +1,6 @@
+require 'rspec/core/rake_task'
+
+desc "Run specs"
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "./spec"
+end

--- a/vendor/extensions/one_boxes/tasks/testing.rake
+++ b/vendor/extensions/one_boxes/tasks/testing.rake
@@ -1,0 +1,8 @@
+namespace :refinery do
+  namespace :testing do
+    # Put any code in here that you want run when you test this extension against a dummy app.
+    # For example, the call to require your gem and start your generator.
+    task :setup_extension do
+    end
+  end
+end


### PR DESCRIPTION
Resolves #240 .

# Why is this change necessary?
Admin users would like an interface to be able to update the one-box elements on the front page.

# How does it address the issue?
This creates an administrative interface to create one box elements. We have a toggle so users can decide what they want the triangle overlay style to reflect and we have a toggle so users can decide if the boxes are visible at all. We also respect the order users put the boxes in.