### PR TITLE
Resolve Learn More Button Link Not Updating

### DIFF
--- a/app/javascript/packs/carousel.js
+++ b/app/javascript/packs/carousel.js
@@ -116,7 +116,7 @@ function genDisplay(data, carouselContainer) {
     }
     event.target.setAttribute('class', 'announcements__number announcements__number--selected');
 
-    carouselContainer.querySelector('.button').setAttribute('href', link)
+    carouselContainer.querySelector('.announcements__button').setAttribute('href', link)
   };
   return displayAnnouncement;
 }


### PR DESCRIPTION
This fixes the issue of the Learn More button link not updating by changing the selector used by the Javascript to update the link href.
