### PR TITLE
Refactor hero image rotation javascript and rspec test

### DIFF
--- a/app/javascript/packs/hero-rotation.js
+++ b/app/javascript/packs/hero-rotation.js
@@ -53,4 +53,12 @@ window.addEventListener('load', () => {
       }, heroBackgroundSpeed)
     }
   });
+
+  const rotationTest = () => {
+    let defaultImage = "url(/assets/bike-lane-9a390139592f024c13cf339a039dec2e7a7f42b5bb5a1951f59c0f55ddf6ab56.jpg)"
+    let imageDivs = Array.from(getImageElements())
+    return imageDivs[0].style.backgroundImage != defaultImage
+  };
+
+  window.rotationTest = rotationTest;
 });

--- a/spec/system/hero_rotation_spec.rb
+++ b/spec/system/hero_rotation_spec.rb
@@ -7,50 +7,50 @@ RSpec.describe "Hero image rotation", :type => :system do
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
+    expect(page.evaluate_script("rotationTest()")).to be(true)
   end
-
+  
   it "works with English language selected", js: true do
     create(:page)
     create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/en/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
+    expect(page.evaluate_script("rotationTest()")).to be(true)
   end
-
+  
   it "works with Portugese language selected", js: true do
     create(:page)
     create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/pt/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
+    expect(page.evaluate_script("rotationTest()")).to be(true)
   end
-
+  
   it "works with Spanish language selected", js: true do
     create(:page)
     create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/es/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
+    expect(page.evaluate_script("rotationTest()")).to be(true)
   end
-
+  
   it "works with Chinese language selected", js: true do
     create(:page)
     create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/zh/"
     sleep 3
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
+    expect(page.evaluate_script("rotationTest()")).to be(true)
   end
-
+  
   it "works with French language selected", js: true do
     create(:page)
     create(:hero_image, image: build(:alternate_image))
     Capybara.current_session.driver.browser.manage.window.resize_to(1440, 1000)
     visit "/fr/"
-    expect(page.find('div.rotation-test')[:style].split('/').last == ("beach-alternate.jpeg\");")).to be(true)
+    expect(page.evaluate_script("rotationTest()")).to be(true)
   end
 end


### PR DESCRIPTION
Resolves the broken test for hero image rotation.

# Why is this change necessary?
With refactoring of hero image rotation, we changed what the test was checking for, rendering the tests ineffective.

# How does it address the issue?
This code adds a javascript function to verify that the hero section background image is NOT the same as the default background image. 

# What side effects does it have?
None. 