### PR TITLE
Resolve #287 Sort Weigh In Stories

### DIFF
--- a/spec/models/story_spec.rb
+++ b/spec/models/story_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+RSpec.describe Refinery::Stories::Story, :type => :model do
+  context "with 0 previous models" do
+    it "sets position to 0" do
+      story = FactoryBot.create(:story, title: 'Test Title')
+      expect(story.reload.position).to eq(0)
+    end
+  end
+
+  context "with 1 previous model" do
+    it "sets position to 1" do
+      FactoryBot.create(:story, title: 'Story 1')
+      story2 = FactoryBot.create(:story, title: 'Story 2')
+      expect(story2.reload.position).to eq(1)
+    end
+  end
+end

--- a/vendor/extensions/stories/app/models/refinery/stories/story.rb
+++ b/vendor/extensions/stories/app/models/refinery/stories/story.rb
@@ -7,6 +7,7 @@ module Refinery
       validate :has_attached_story
       before_validation :generate_title
       after_save :create_transcript
+      after_initialize :set_position
       enum question: [:question1, :question2]
 
       extend Mobility
@@ -36,6 +37,10 @@ module Refinery
       def generate_title
         return nil if question.blank? || submitter_name.blank?
         self.title = submitter_name + ' | ' + question
+      end
+
+      def set_position
+        self.position ||= Story.maximum('position') + 1
       end
     end
   end

--- a/vendor/extensions/stories/app/models/refinery/stories/story.rb
+++ b/vendor/extensions/stories/app/models/refinery/stories/story.rb
@@ -40,7 +40,7 @@ module Refinery
       end
 
       def set_position
-        self.position ||= Story.maximum('position') + 1
+        self.position ||= Story.maximum('position') ? Story.maximum('position') + 1 : 0
       end
     end
   end

--- a/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_sortable_list.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_sortable_list.html.erb
@@ -1,3 +1,4 @@
+<h2>display order. user | question | visible</h2>
 <ul id='sortable_list'>
   <%= render :partial => 'story', :collection => @stories %>
 </ul>

--- a/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_story.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/admin/stories/_story.html.erb
@@ -1,9 +1,14 @@
 <li class='clearfix record <%= cycle("on", "on-hover") %>' id="<%= dom_id(story) -%>">
+  <span class='position'><%= story.position + 1 %>.</span>
   <span class='title'>
     <%= story.title %>
   </span>
 
   <span class='preview'></span>
+
+  <span class='display'>
+    | <%= story.display %>
+  </span>
 
   <span class='actions'>
     <%= action_icon(:preview, refinery.stories_story_path(story), t('.view_live_html')) %>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
@@ -21,7 +21,7 @@
 
   <% if @stories.any? %>
     <section class="stories container">
-      <% @stories.each do |story| %>
+      <% @stories.order(:position).each do |story| %>
         <div class="story">
           <div class="story-meta">
             <span class="story-date"><%= story.created_at.to_formatted_s(:simplified) %></span>


### PR DESCRIPTION
* Update admin interface to display numbers to enumerate the sort order of stories.
* Update the admin interface to display whether a story is visible in the index page
* Update the stories view page to sort the stories by the position number
* Update the story model to automatically assign a position number that is the highest value availalbe for a story.
