### PR TITLE
Bjs/274 weigh in header

### DIFF
--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -2,8 +2,8 @@
 
   .banner {
     background: $color_bg-dark;
-    width: 100%;
     height: 80px;
+    width: 100%;
   }
 
   #page_container {
@@ -11,31 +11,32 @@
     padding: 0;
   }
 
-  .weigh-in__header-container {
-    background-color: $color_bg-lightest;
-    background-image: url('group-2111.png');
-    
+  .weigh-in__header-background {
     @include media(small) {
       background: none;
     }
 
+    background-color: $color_bg-lightest;
+    background-image: url('group-2111.png');
+  }
+
   .weigh-in__header {
-    display: grid;
-    height: 29.3rem;
-    grid-template-columns: 1fr 54rem 1fr;
-    grid-template-rows: 1fr 15.5rem 1fr;
-    
     @include media(medium) {
       grid-template-columns: 1fr 40rem 1fr;
       grid-template-rows: 1fr 24rem 1fr;
     }
-    
+
     @include media(small) {
-      height: 25.05rem;
       grid-template-columns: 1fr 22rem 1fr;
       grid-template-rows: 3rem 1fr 1.5rem;
+      height: 25.05rem;
       margin-bottom: 6rem;
     }
+
+    display: grid;
+    grid-template-columns: 1fr 54rem 1fr;
+    grid-template-rows: 1fr 15.5rem 1fr;
+    height: 29.3rem;
 
     &--content {
       grid-column-start: 2;
@@ -43,35 +44,35 @@
     }
 
     &--title {
-      color: $v3-color_black-dark;
-      font-size: $v3_font_size-h1;
-
       @include media(small) {
         font-size: $v3_font_size-title;
-        ;
       }
+
+      color: $v3-color_black-dark;
+      font-size: $v3_font_size-h1;
     }
 
     &--text {
-      color: $v3-color_black-dark;
-      font-size: $font_size_medium;
-      font-family: $font_family-primary;
-
       @include media(small) {
         font-size: $font_size-small;
-        ;
       }
+
+      color: $v3-color_black-dark;
+      font-family: $font_family-primary;
+      font-size: $font_size_medium;
     }
   }
 
-  input[type="submit"] {
+  input[type='submit'] {
     background: $color_bg-lightest;
-    color: $color_green-dark;
     border: 1px solid $color_green-dark;
+    color: $color_green-dark;
   }
 
-  a.button {
-    text-decoration: none;
+  a {
+    .button {
+      text-decoration: none;
+    }
   }
 
   .audio-response,
@@ -85,8 +86,8 @@
   }
 
   .banner-content {
-    margin-top: 7rem;
     margin-bottom: 7.5rem;
+    margin-top: 7rem;
   }
 
   .content-column {
@@ -96,16 +97,15 @@
   }
 
   .no-content-message {
-    margin-top: 2rem;
-
     color: $color_font-grey;
     font-style: italic;
+    margin-top: 2rem;
   }
 
   .or {
     display: inline-block;
-    vertical-align: center;
     padding: 1.5em 1em;
+    vertical-align: center;
   }
 
   .story {
@@ -117,11 +117,10 @@
   }
 
   .story-meta {
-    margin-bottom: $font_size-base;
-
     color: $color_green-dark;
-    font-style: italic;
     font-size: $font_size-xsmall;
+    font-style: italic;
+    margin-bottom: $font_size-base;
   }
 
   .transcript {
@@ -129,13 +128,12 @@
   }
 
   .quote-mark {
-    display: inline-block;
-    top: 8px;
-    height: 0;
-
     color: $color_green-dark;
+    display: inline-block;
     font-size: $font_size-large;
     font-style: italic;
+    height: 0;
+    top: 8px;
   }
 
   .video-info {
@@ -176,11 +174,11 @@
       }
 
       label {
-        display: inline-block;
         background-color: $color_bg-grey;
-        padding: 10px 20px;
-        font-size: 16px;
         cursor: pointer;
+        display: inline-block;
+        font-size: 16px;
+        padding: 10px 20px;
       }
 
       input[type="radio"]:checked+label {
@@ -189,35 +187,29 @@
     }
 
     .form-break {
+      color: $color_font-grey;
       display: flex;
-
+      font-size: $font_size-small;
       margin: $font_size-base 0;
 
-      color: $color_font-grey;
-      font-size: $font_size-small;
-
-      &:before,
-      &:after {
-        content: '';
-
-        flex: 1 1;
-        position: relative;
-        display: inline-block;
-
-        height: 1px;
-        width: auto;
-        margin: auto $font_size-base;
-
+      &::before,
+      &::after {
         background: $color_bg-dark;
+        content: '';
+        display: inline-block;
+        flex: 1 1;
+        height: 1px;
+        margin: auto $font_size-base;
+        position: relative;
+        width: auto;
       }
     }
 
     .text-response {
       textarea {
-        width: 100%;
         min-height: 200px;
+        width: 100%;
       }
     }
   }
-
 }

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -17,21 +17,28 @@
     max-width: 100%;
     background-color: $color_bg-lightest;
     background-image: url('group-2111.png');
+
+    @include media(small) {
+      background: none;
+    }
   }
 
   .weigh-in__header {
     display: grid;
+    height: 29.3rem;
     grid-template-columns: 1fr 54rem 1fr;
-    grid-template-rows: 11.35rem 1fr 8.3rem;
-
+    grid-template-rows: 1fr 15.5rem 1fr;
+    
     @include media(medium) {
       grid-template-columns: 1fr 40rem 1fr;
-      grid-template-rows: 11.35rem 1fr 8.3rem;
+      grid-template-rows: 1fr 24rem 1fr;
     }
-
+    
     @include media(small) {
+      height: 25.05rem;
       grid-template-columns: 1fr 22rem 1fr;
       grid-template-rows: 3rem 1fr 1.5rem;
+      margin-bottom: 6rem;
     }
 
     &--content {

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -21,21 +21,16 @@
 
   .weigh-in__header {
     display: grid;
-    grid-template-columns: 29.95rem 1fr 15.6rem;
-    grid-template-rows: 10.25rem 1fr 8.3rem;
-
-    @include media(large) {
-      grid-template-columns: 15rem 1fr 7rem;
-      grid-template-rows: 10.25rem 1fr 8.3rem;
-    }
+    grid-template-columns: 1fr 54rem 1fr;
+    grid-template-rows: 11.35rem 1fr 8.3rem;
 
     @include media(medium) {
-      grid-template-columns: 1.25rem 1fr 2.4rem;
-      grid-template-rows: 10.25rem 1fr 8.3rem;
+      grid-template-columns: 1fr 40rem 1fr;
+      grid-template-rows: 11.35rem 1fr 8.3rem;
     }
 
     @include media(small) {
-      grid-template-columns: 1.25rem 1fr 2.4rem;
+      grid-template-columns: 1fr 22rem 1fr;
       grid-template-rows: 3rem 1fr 1.5rem;
     }
 
@@ -60,7 +55,7 @@
       font-family: $font_family-primary;
 
       @include media(small) {
-        font-size: $font_size-xsmall;
+        font-size: $font_size-small;
         ;
       }
     }
@@ -165,7 +160,6 @@
   .right-buttons {
     float: right;
   }
-
 
   .story-form-wrapper {
     h4 {

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -22,25 +22,23 @@
 
   .weigh-in__header {
     @include media(medium) {
-      grid-template-columns: 1fr 40rem 1fr;
-      grid-template-rows: 1fr 24rem 1fr;
+      grid-template-columns: 2fr 40rem 1fr;
     }
 
     @include media(small) {
-      grid-template-columns: 1fr 22rem 1fr;
-      grid-template-rows: 3rem 1fr 1.5rem;
-      height: 25.05rem;
-      margin-bottom: 6rem;
+      grid-template-columns: auto;
+      margin: initial;
+      padding: 3.75rem 1rem 0;
     }
 
     display: grid;
-    grid-template-columns: 1fr 54rem 1fr;
-    grid-template-rows: 1fr 15.5rem 1fr;
-    height: 29.3rem;
+    grid-template-columns: 2fr 54rem 1fr;
+    padding-top: 8.3rem;
+    padding-bottom: 8.3rem;
+
 
     &--content {
       grid-column-start: 2;
-      grid-row-start: 2;
     }
 
     &--title {

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
@@ -1,9 +1,9 @@
 <div class="StoriesPage">
   <div class="banner"></div> <!-- top green bar -->
   <div class="weigh-in__header-background">
-    <section class="weigh-in__header container">
+    <section class="weigh-in__header">
       <div class="weigh-in__header--content">
-        <div class="weigh-in__header--title">Weigh in...</div>
+        <span class="weigh-in__header--title">Weigh in...</span>
         <p class="weigh-in__header--text">
           Opinions, ideas, and priorities that spring from the lived experience of the people of the region are an
           important part of MetroCommon. We’re collecting public input at every stage of the planning process.

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
@@ -1,6 +1,6 @@
 <div class="StoriesPage">
   <div class="banner"></div> <!-- top green bar -->
-  <div class="weigh-in__header-container">
+  <div class="weigh-in__header-background">
     <section class="weigh-in__header container">
       <div class="weigh-in__header--content">
         <div class="weigh-in__header--title">Weigh in...</div>


### PR DESCRIPTION
Resolves #274  .

# Why is this change necessary?
Last refactor lost some of the original sizing.
XD proportions of margin, content height & width, was not handled by grid as efficiently as it could have been

# How does it address the issue?
This code makes better use of CSS grid to have proportional margins while retaining the expected content height from XD file. This is accomplished by: 

1. Setting a specific parent container height
2. Setting a specific content height (for the content inside the parent container)
3. Allowing the margins around the content to be handled dynamically by CSS grid.

# What side effects does it have?
The "medium" media query in our code base, is not optimal for this content when you reach a screen width of 960px.  The compromise I chose was to jump to the same top margin as the smallest media query, by increasing the CSS grid middle row height, when you hit the medium media query.

To observe this, open the page and gradually decrease browser size to see the media queries kick in. 
At the medium query, you'll see the content "jump" up to the same top margin as the mobile size.

