### PR TITLE
Resolve #298 Weigh in Prompt

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,3 +91,5 @@ gem 'refinerycms-announcements', path: 'vendor/extensions'
 
 gem 'refinerycms-hero_images', path: 'vendor/extensions'
 gem 'refinerycms-one_boxes', path: 'vendor/extensions'
+
+gem 'refinerycms-weigh_in_prompts', path: 'vendor/extensions'

--- a/Gemfile
+++ b/Gemfile
@@ -49,6 +49,8 @@ group :development do
   gem "capistrano-bundler"
   gem "capistrano-passenger"
   gem "capistrano-rvm"
+  gem "pry-rescue"
+  gem "pry-stack_explorer"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -87,6 +87,9 @@ PATH
     refinerycms-stories (1.0)
       acts_as_indexed (~> 0.8.0)
       refinerycms-core (~> 4.0.2)
+    refinerycms-weigh_in_prompts (1.0)
+      acts_as_indexed (~> 0.8.0)
+      refinerycms-core (~> 4.0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -665,6 +668,7 @@ DEPENDENCIES
   refinerycms-one_boxes!
   refinerycms-search!
   refinerycms-stories!
+  refinerycms-weigh_in_prompts!
   refinerycms-wymeditor (~> 2.0, >= 2.0.0)
   rspec-rails
   sassc-rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,8 @@ GEM
     babosa (1.0.2)
     bcrypt (3.1.12)
     bindex (0.5.0)
+    binding_of_caller (0.8.0)
+      debug_inspector (>= 0.0.1)
     bootsnap (1.4.2)
       msgpack (~> 1.0)
     browserstack-local (1.3.0)
@@ -213,6 +215,7 @@ GEM
     concurrent-ruby (1.1.5)
     connection_pool (2.2.2)
     crass (1.0.4)
+    debug_inspector (0.0.3)
     declarative (0.0.10)
     declarative-option (0.1.0)
     decorators (2.0.4)
@@ -357,6 +360,7 @@ GEM
     i18n (1.0.1)
       concurrent-ruby (~> 1.0)
     ice_nine (0.11.2)
+    interception (0.5)
     ipaddress (0.8.3)
     jmespath (1.4.0)
     jquery-rails (4.3.3)
@@ -422,6 +426,12 @@ GEM
       pry (~> 0.10)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
+    pry-rescue (1.5.0)
+      interception (>= 0.5)
+      pry (>= 0.12.0)
+    pry-stack_explorer (0.4.9.3)
+      binding_of_caller (>= 0.7)
+      pry (>= 0.9.11)
     public_suffix (3.0.3)
     puma (3.12.1)
     rack (2.0.7)
@@ -656,6 +666,8 @@ DEPENDENCIES
   pg
   pry-byebug
   pry-rails
+  pry-rescue
+  pry-stack_explorer
   puma
   rails (~> 5.2)
   refinerycms (~> 4.0)!

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -139,7 +139,6 @@
     }
 
     &--prompt-large {
-      background-image: image-url('middlesex-fells-credit-paul-w.jpg');
       font-size: $font_size-xlarge;
       height: 20rem;
       margin-bottom: 2.5rem;

--- a/db/migrate/20190425185809_create_weigh_in_prompts_weigh_in_prompts.refinery_weigh_in_prompts.rb
+++ b/db/migrate/20190425185809_create_weigh_in_prompts_weigh_in_prompts.refinery_weigh_in_prompts.rb
@@ -1,0 +1,27 @@
+# This migration comes from refinery_weigh_in_prompts (originally 1)
+class CreateWeighInPromptsWeighInPrompts < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :refinery_weigh_in_prompts do |t|
+      t.string :title
+      t.integer :image_id
+      t.text :body
+      t.integer :style
+      t.integer :position
+
+      t.timestamps
+    end
+
+
+  end
+
+
+  def down
+    if defined?(::Refinery::UserPlugin)
+      ::Refinery::UserPlugin.destroy_all({:name => "refinerycms-weigh_in_prompts"})
+    end
+
+    drop_table :refinery_weigh_in_prompts
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_11_195508) do
+ActiveRecord::Schema.define(version: 2019_04_25_185809) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -287,6 +287,16 @@ ActiveRecord::Schema.define(version: 2019_04_11_195508) do
     t.datetime "updated_at", null: false
     t.index ["locale"], name: "index_refinery_story_translations_on_locale"
     t.index ["refinery_story_id", "locale"], name: "index_845caebe798a0afcd0ff8f6d31a500cb83b87df7", unique: true
+  end
+
+  create_table "refinery_weigh_in_prompts", force: :cascade do |t|
+    t.string "title"
+    t.integer "image_id"
+    t.text "body"
+    t.integer "style"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "seo_meta", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -30,3 +30,6 @@ Refinery::HeroImages::Engine.load_seed
 
 # Added by Refinery CMS OneBoxes extension
 Refinery::OneBoxes::Engine.load_seed
+
+# Added by Refinery CMS WeighInPrompts extension
+Refinery::WeighInPrompts::Engine.load_seed

--- a/spec/system/weigh_in_prompts.rb
+++ b/spec/system/weigh_in_prompts.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe "Weigh In Prompts", :type => :system do
+  it "displays a large weigh in prompt" do
+    create_list(:story, 3)
+    prompt1 = create(:weigh_in_prompt)
+    visit "/stories"
+    expect(page).to have_css('div.story--prompt-large')
+  end
+
+  it "displays a small weigh in prompt" do
+    create_list(:story, 10)
+    prompt1 = create(:weigh_in_prompt)
+    prompt2 = create(:weigh_in_prompt, style: 'small')
+    visit "/stories"
+    expect(page).to have_css('div.story--prompt-small')
+  end
+
+  it "does not display small prompt with too few stories" do
+    create_list(:story, 4)
+    prompt1 = create(:weigh_in_prompt)
+    prompt2 = create(:weigh_in_prompt, style: 'small')
+    visit "/stories"
+    expect(page).not_to have_css('div.story--prompt-small')
+  end
+end

--- a/vendor/extensions/announcements/app/serializers/announcement_serializer.rb
+++ b/vendor/extensions/announcements/app/serializers/announcement_serializer.rb
@@ -2,7 +2,6 @@ class AnnouncementSerializer
   include FastJsonapi::ObjectSerializer
   attributes :title, :link, :position
   has_one :image
-  # belongs_to :owner, record_type: :user
 
   attribute :sanitized_body do |record|
     Rails::Html::WhiteListSanitizer.new.sanitize(record.body)

--- a/vendor/extensions/stories/app/controllers/refinery/stories/stories_controller.rb
+++ b/vendor/extensions/stories/app/controllers/refinery/stories/stories_controller.rb
@@ -8,6 +8,7 @@ module Refinery
       def index
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @story in the line below:
+        @weigh_in_prompts = ::Refinery::WeighInPrompts::WeighInPrompt.all
         present(@page)
       end
 

--- a/vendor/extensions/stories/app/helpers/refinery/stories/stories_helper.rb
+++ b/vendor/extensions/stories/app/helpers/refinery/stories/stories_helper.rb
@@ -22,12 +22,12 @@ module Refinery
       end
 
       def next_prompt(current_prompt, count)
-        if current_prompt.id == count
-          next_prompt_id = 1
+        if current_prompt.id >= ::Refinery::WeighInPrompts::WeighInPrompt.maximum(:id)
+          next_prompt_id = ::Refinery::WeighInPrompts::WeighInPrompt.minimum(:id)
         else
           next_prompt_id = current_prompt.id + 1
         end
-        prompt.find(next_prompt_id)
+        ::Refinery::WeighInPrompts::WeighInPrompt.find(next_prompt_id)
       end
 
       def insert_prompts(stories, prompts)

--- a/vendor/extensions/stories/app/helpers/refinery/stories/stories_helper.rb
+++ b/vendor/extensions/stories/app/helpers/refinery/stories/stories_helper.rb
@@ -21,23 +21,24 @@ module Refinery
         end
       end
 
-      def next_prompt(current_prompt)
-        if current_prompt[:prompt] == 'small'
-          {"prompt": "large"}
+      def next_prompt(current_prompt, count)
+        if current_prompt.id == count
+          next_prompt_id = 1
         else
-          {"prompt": "small"}
+          next_prompt_id = current_prompt.id + 1
         end
+        prompt.find(next_prompt_id)
       end
 
-      def insert_prompts(stories)
+      def insert_prompts(stories, prompts)
         stories_array = stories.to_a
-        current_prompt = {"prompt": "large"}
+        current_prompt = prompts.first
         stories_array.insert(1, current_prompt)
         stories_index_array = (0..stories.length-1).to_a
 
         stories_array.each_with_index do |story, index|
           if index % 5 == 0 && index != 0
-            current_prompt = next_prompt(current_prompt)
+            current_prompt = next_prompt(current_prompt, prompts.count)
             stories_array.insert(index, current_prompt)
           end
         end

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
@@ -1,9 +1,9 @@
 <div class="media-player">
-  <% if media.video.attached? %>
+  <% if media&.video&.attached? %>
     <div class="story--video">
       <%= video_tag main_app.rails_blob_path(media.video), autoplay: 'autoplay', muted: 'true', controls: 'true' %>
     </div>
-  <% elsif media.audio.attached? %>
+  <% elsif media&.audio&.attached? %>
     <div class="media-player__audio">
       <%= audio_tag main_app.rails_blob_path(media.audio), preload: 'metadata' %>
       <div class="media-player__pause-play"></div>
@@ -14,7 +14,7 @@
       </div>
       <div class="media-player__time">0:00</div>
     </div>
-  <% elsif media.response.present? %>
+  <% elsif media&.response.present? %>
     <div class="story--response">
       &ldquo;<%= media.response %>&rdquo;
       <p class="story__response--submitter-name">- <%= media.submitter_name %></p>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
@@ -1,5 +1,5 @@
-<% if style == "large" %>
-  <div class="story--prompt-large">
+<% if prompt.style == "large" %>
+  <div class="story--prompt-large" style="background-image: url(<%= prompt.image.url %>)">
     <h1>MetroCommon Goals: What do you think?</h1>
   </div>
 <% else %>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
@@ -1,4 +1,4 @@
-<% if prompt == "large" %>
+<% if style == "large" %>
   <div class="story--prompt-large">
     <h1>MetroCommon Goals: What do you think?</h1>
   </div>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
@@ -1,9 +1,9 @@
 <% if prompt.style == "large" %>
   <div class="story--prompt-large" style="background-image: url(<%= prompt.image.url %>)">
-    <h1>MetroCommon Goals: What do you think?</h1>
+    <h1><%= strip_tags(prompt.body) %></h1>
   </div>
 <% else %>
   <div class="story--prompt-small">
-    <%= link_to 'Share what you want the region to be like in 2050!', refinery.new_stories_story_path %>
+    <%= link_to strip_tags(prompt.body), refinery.new_stories_story_path %>
   </div>
 <% end %>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
@@ -27,14 +27,14 @@
 
   <section id="stories" class="stories container">
     <% if @stories.any? %>
-      <% insert_prompts(@stories).each do |story| %>
-        <% if story[:prompt] %>
+      <% insert_prompts(@stories, @weigh_in_prompts).each do |story| %>
+        <% if story.class.name == 'Refinery::WeighInPrompts::WeighInPrompt' %>
           <div>
-            <%= render partial: 'prompt', locals: { prompt: story[:prompt] } %>
+            <%= render partial: 'prompt', locals: { style: story.style } %>
           </div>
         <% else %>
           <div class="story">
-            <%= render partial: 'media', locals: { media: story } %>  
+            <%= render partial: 'media', locals: { media: story } %>
           </div>
         <% end %>
       <% end %>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
@@ -27,14 +27,14 @@
 
   <section id="stories" class="stories container">
     <% if @stories.any? %>
-      <% insert_prompts(@stories, @weigh_in_prompts).each do |story| %>
-        <% if story.class.name == 'Refinery::WeighInPrompts::WeighInPrompt' %>
-          <div>
-            <%= render partial: 'prompt', locals: { style: story.style } %>
+      <% insert_prompts(@stories, @weigh_in_prompts).each do |content| %>
+        <% if content.class.name == 'Refinery::WeighInPrompts::WeighInPrompt' %>
+          <div class="story">
+            <%= render partial: 'prompt', locals: { prompt: content } %>
           </div>
         <% else %>
           <div class="story">
-            <%= render partial: 'media', locals: { media: story } %>
+            <%= render partial: 'media', locals: { media: content } %>
           </div>
         <% end %>
       <% end %>

--- a/vendor/extensions/stories/db/seeds.rb
+++ b/vendor/extensions/stories/db/seeds.rb
@@ -16,11 +16,4 @@ Refinery::I18n.frontend_locales.each do |lang|
       page.parts.build title: part[:title], slug: part[:slug], body: nil, position: index
     end
   end if defined?(Refinery::Page)
-
-  Refinery::Stories::Story.first_or_create!(title: 'Matt Zagaja | question1') do |story|
-    story.submitter_name = 'Matt Zagaja'
-    story.question = 'question1'
-    story.response = 'Hyperloop!'
-    story.display = true
-  end if defined?(Refinery::Stories)
 end

--- a/vendor/extensions/weigh_in_prompts/Gemfile
+++ b/vendor/extensions/weigh_in_prompts/Gemfile
@@ -1,0 +1,43 @@
+source "https://rubygems.org"
+
+gemspec
+
+git 'https://github.com/refinery/refinerycms.git', :branch => 'master' do
+  gem 'refinerycms'
+
+  group :development, :test do
+    gem 'refinerycms-testing'
+  end
+end
+
+# Database Configuration
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'activerecord-jdbcmysql-adapter'
+  gem 'activerecord-jdbcpostgresql-adapter'
+  gem 'jruby-openssl'
+end
+
+platforms :ruby do
+  gem 'sqlite3'
+  gem 'mysql2', '~> 0.4.10'
+  gem 'pg'
+end
+
+group :development, :test do
+  gem 'rspec-its' # for the model's validation tests.
+  platforms :ruby do
+    require 'rbconfig'
+    if RbConfig::CONFIG['target_os'] =~ /linux/i
+      gem 'therubyracer', '~> 0.11.4'
+    end
+  end
+end
+
+# Gems used only for assets and not required
+# in production environments by default.
+group :assets do
+  gem 'sass-rails'
+  gem 'coffee-rails'
+  gem 'uglifier'
+end

--- a/vendor/extensions/weigh_in_prompts/Rakefile
+++ b/vendor/extensions/weigh_in_prompts/Rakefile
@@ -1,0 +1,19 @@
+#!/usr/bin/env rake
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+ENGINE_PATH = File.dirname(__FILE__)
+APP_RAKEFILE = File.expand_path "../spec/dummy/Rakefile", __FILE__
+
+if File.exists? APP_RAKEFILE
+  load 'rails/tasks/engine.rake'
+end
+
+require "refinerycms-testing"
+Refinery::Testing::Railtie.load_dummy_tasks ENGINE_PATH
+
+load File.expand_path('../tasks/testing.rake', __FILE__)
+load File.expand_path('../tasks/rspec.rake', __FILE__)

--- a/vendor/extensions/weigh_in_prompts/app/controllers/refinery/weigh_in_prompts/admin/weigh_in_prompts_controller.rb
+++ b/vendor/extensions/weigh_in_prompts/app/controllers/refinery/weigh_in_prompts/admin/weigh_in_prompts_controller.rb
@@ -1,0 +1,17 @@
+module Refinery
+  module WeighInPrompts
+    module Admin
+      class WeighInPromptsController < ::Refinery::AdminController
+
+        crudify :'refinery/weigh_in_prompts/weigh_in_prompt'
+
+        private
+
+        # Only allow a trusted parameter "permit list" through.
+        def weigh_in_prompt_params
+          params.require(:weigh_in_prompt).permit(:title, :image_id, :body, :style)
+        end
+      end
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/app/models/refinery/weigh_in_prompts/weigh_in_prompt.rb
+++ b/vendor/extensions/weigh_in_prompts/app/models/refinery/weigh_in_prompts/weigh_in_prompt.rb
@@ -17,7 +17,7 @@ module Refinery
       private
 
       def set_position
-        self.position ||= Story.maximum('position') ? Story.maximum('position') + 1 : 0
+        self.position ||= WeighInPrompt.maximum('position') ? WeighInPrompt.maximum('position') + 1 : 0
       end
 
     end

--- a/vendor/extensions/weigh_in_prompts/app/models/refinery/weigh_in_prompts/weigh_in_prompt.rb
+++ b/vendor/extensions/weigh_in_prompts/app/models/refinery/weigh_in_prompts/weigh_in_prompt.rb
@@ -1,0 +1,25 @@
+module Refinery
+  module WeighInPrompts
+    class WeighInPrompt < Refinery::Core::BaseModel
+      self.table_name = 'refinery_weigh_in_prompts'
+      enum style: [:large, :small]
+      after_initialize :set_position
+
+
+      validates :title, :presence => true, :uniqueness => true
+
+      belongs_to :image, :class_name => '::Refinery::Image'
+
+      # To enable admin searching, add acts_as_indexed on searchable fields, for example:
+      #
+      #   acts_as_indexed :fields => [:title]
+
+      private
+
+      def set_position
+        self.position ||= Story.maximum('position') ? Story.maximum('position') + 1 : 0
+      end
+
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_actions.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_actions.html.erb
@@ -1,0 +1,20 @@
+<ul>
+  <% if ::Refinery::WeighInPrompts::Admin::WeighInPromptsController.searchable? %>
+    <li>
+      <%= render '/refinery/admin/search', :url => refinery.weigh_in_prompts_admin_weigh_in_prompts_path %>
+    </li>
+  <% end %>
+  <li>
+    <%= action_label :add, refinery.new_weigh_in_prompts_admin_weigh_in_prompt_path, t('.create_new') %>
+  </li>
+<% if !searching? && ::Refinery::WeighInPrompts::Admin::WeighInPromptsController.sortable? && ::Refinery::WeighInPrompts::WeighInPrompt.many? %>
+  <li>
+    <%= action_label :reorder,
+                     refinery.weigh_in_prompts_admin_weigh_in_prompts_path,
+                     t('.reorder', what:  "Weigh In Prompts"), id: 'reorder_action'%>
+    <%= action_label :reorder_done,
+                     refinery.weigh_in_prompts_admin_weigh_in_prompts_path,
+                      t('.reorder_done', what: "Weigh In Prompts"), id: 'reorder_action_done', class: 'hidden'%>
+  </li>
+<% end %>
+</ul>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_form.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_form.html.erb
@@ -1,0 +1,45 @@
+<%= form_for [refinery, :weigh_in_prompts_admin, @weigh_in_prompt] do |f| -%>
+  <%= render '/refinery/admin/error_messages',
+              :object => @weigh_in_prompt,
+              :include_object_name => true %>
+
+  <div class='field'>
+    <%= f.label :title -%>
+    <%= f.text_field :title, :class => 'larger widest' -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :image -%>
+    <%= render '/refinery/admin/image_picker',
+               :f => f,
+               :field => :image_id,
+               :image => @weigh_in_prompt.image,
+               :toggle_image_display => false -%>
+  </div>
+
+  <div class='field'>
+    <%= render '/refinery/admin/wysiwyg',
+                :f => f,
+                :fields => [:body],
+                :object => "weigh_in_prompts/weigh_in_prompt" -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :style -%>
+    <%= f.number_field :style -%>
+  </div>
+
+  <%= render '/refinery/admin/form_actions', f: f,
+             continue_editing: false,
+             delete_title: t('delete', scope: 'refinery.weigh_in_prompts.admin.weigh_in_prompts.weigh_in_prompt'),
+             delete_confirmation: t('message', scope: 'refinery.admin.delete', title: @weigh_in_prompt.title),
+             cancel_url: refinery.weigh_in_prompts_admin_weigh_in_prompts_path -%>
+<% end -%>
+
+<% content_for :javascripts do -%>
+  <script>
+    $(document).ready(function(){
+      page_options.init(false, '', '');
+    });
+  </script>
+<% end -%>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_form.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_form.html.erb
@@ -25,8 +25,15 @@
   </div>
 
   <div class='field'>
-    <%= f.label :style -%>
-    <%= f.number_field :style -%>
+    <h3>Box Style</h3>
+    <%= f.label :style, value: 'large' do %>
+      <%= f.radio_button(:style, 'large') %>
+      Large
+    <% end %>
+    <%= f.label :style, value: 'small' do %>
+      <%= f.radio_button(:style, 'small') %>
+      Small
+    <% end %>
   </div>
 
   <%= render '/refinery/admin/form_actions', f: f,

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_records.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_records.html.erb
@@ -1,0 +1,16 @@
+<%= render 'refinery/admin/search_header', :url => refinery.weigh_in_prompts_admin_weigh_in_prompts_path %>
+<div class='pagination_container'>
+  <% if @weigh_in_prompts.any? %>
+    <%= render 'weigh_in_prompts' %>
+  <% else %>
+    <p>
+      <% if searching? %>
+        <%= t('no_results', :scope => 'refinery.admin.search') %>
+      <% else %>
+        <strong>
+          <%= t('.no_items_yet') %>
+        </strong>
+      <% end %>
+    </p>
+  <% end %>
+</div>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_sortable_list.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_sortable_list.html.erb
@@ -1,0 +1,5 @@
+<ul id='sortable_list'>
+  <%= render :partial => 'weigh_in_prompt', :collection => @weigh_in_prompts %>
+</ul>
+<%= render '/refinery/admin/sortable_list',
+            :continue_reordering => (local_assigns.keys.include?(:continue_reordering)) ? continue_reordering : true %>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_weigh_in_prompt.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_weigh_in_prompt.html.erb
@@ -1,0 +1,15 @@
+<li class='clearfix record <%= cycle("on", "on-hover") %>' id="<%= dom_id(weigh_in_prompt) -%>">
+  <span class='title'>
+    <%= weigh_in_prompt.title %>
+  </span>
+
+  <span class='preview'></span>
+
+  <span class='actions'>
+    
+    <%= action_icon(:edit,    refinery.edit_weigh_in_prompts_admin_weigh_in_prompt_path(weigh_in_prompt), t('.edit') ) %>
+    <%= action_icon(:delete,  refinery.weigh_in_prompts_admin_weigh_in_prompt_path(weigh_in_prompt), t('.delete'),
+      { class: "cancel confirm-delete",
+        data: {confirm: t('message',  scope: 'refinery.admin.delete', title: weigh_in_prompt.title)}}  ) %>
+  </span>
+</li>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_weigh_in_prompts.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/_weigh_in_prompts.html.erb
@@ -1,0 +1,2 @@
+<%= will_paginate @weigh_in_prompts if Refinery::WeighInPrompts::Admin::WeighInPromptsController.pageable? %>
+<%= render 'sortable_list' %>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/edit.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/index.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/index.html.erb
@@ -1,0 +1,7 @@
+<section id='records'>
+  <%= render 'records' %>
+</section>
+<aside id='actions'>
+  <%= render 'actions' %>
+</aside>
+<%= render '/refinery/admin/make_sortable', options: {tree: false} if !searching? and ::Refinery::WeighInPrompts::Admin::WeighInPromptsController.sortable? and ::Refinery::WeighInPrompts::WeighInPrompt.many? %>

--- a/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/new.html.erb
+++ b/vendor/extensions/weigh_in_prompts/app/views/refinery/weigh_in_prompts/admin/weigh_in_prompts/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/vendor/extensions/weigh_in_prompts/config/locales/cs.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/cs.yml
@@ -1,0 +1,30 @@
+cs:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Přidat Weigh In Prompt
+            reorder: Řadit Weigh In Prompts
+            reorder_done: Konec řazení Weigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: Litujeme, ale nebyly nalezny žádné výsledky.
+            no_items_yet: Zatím nebyly vytvořeny žádné Weigh In Prompts. Zvolte "Přidat Weigh In Prompt" pro přidání prvního weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: Zobrazit náhled weigh in prompt<br/><em>(otevře se v novém okně)</em>
+            edit: Upravit weigh in prompt
+            delete: Smazat weigh in prompt
+      weigh_in_prompts:
+        show:
+          other: Další Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/en.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/en.yml
@@ -1,0 +1,30 @@
+en:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Add New Weigh In Prompt
+            reorder: Reorder Weigh In Prompts
+            reorder_done: Done Reordering Weigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: Sorry! There are no results found.
+            no_items_yet: There are no Weigh In Prompts yet. Click "Add New Weigh In Prompt" to add your first weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: View this weigh in prompt live <br/><em>(opens in a new window)</em>
+            edit: Edit this weigh in prompt
+            delete: Remove this weigh in prompt forever
+      weigh_in_prompts:
+        show:
+          other: Other Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/es.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/es.yml
@@ -1,0 +1,31 @@
+es:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+#        article: masculino/femenino
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Crear nuevo weigh in prompt
+            reorder: Reordenar weigh in prompts
+            reorder_done: Reordenación de weigh in prompts completada
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: Lo siento, no hay resultados
+            no_items_yet: No hay weigh in prompts todavía. Pulsa en "Crear nuevo Weigh In Prompt" para crear tu primer weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: Ver este weigh in prompt como abierto al público <br/><em>(abre en ventana nueva)</em>
+            edit: Editar este weigh in prompt
+            delete: Borrar este weigh in prompt para siempre
+      weigh_in_prompts:
+        show:
+          other: Otros weigh in prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/fr.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/fr.yml
@@ -1,0 +1,30 @@
+fr:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Créer un(e) nouve(au/l/lle) Weigh In Prompt
+            reorder: Réordonner les Weigh In Prompts
+            reorder_done: Fin de réordonnancement des Weigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: "Désolé ! Aucun résultat."
+            no_items_yet: 'Il n''y a actuellement aucun(e) Weigh In Prompt. Cliquer sur "Créer un(e) nouve(au/l/lle) Weigh In Prompt" pour créer votre premi(er/ère) weigh in prompt.'
+          weigh_in_prompt:
+            view_live_html: Voir ce(t/tte) weigh in prompt <br/><em>(Ouvre une nouvelle fenêtre)</em>
+            edit: Modifier ce(t/tte) weigh in prompt
+            delete: Supprimer définitivement ce(t/tte) weigh in prompt
+      weigh_in_prompts:
+        show:
+          other: Autres Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/it.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/it.yml
@@ -1,0 +1,30 @@
+it:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Aggiungi Nuovo Weigh In Prompt
+            reorder: Riordina Weigh In Prompts
+            reorder_done: Termina il Riordino di Weigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: "Spiacenti! Nessun risultato trovato"
+            no_items_yet: Non ci sono ancora Weigh In Prompts. Clicca "Aggiungi Nuovo Weigh In Prompt" per aggiungere il tuo primo weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: Guarda live questo weigh in prompt <br/><em>(apre una nuova finestra)</em>
+            edit: Modifica questo weigh in prompt
+            delete: Rimuovi per sempre questo weigh in prompt
+      weigh_in_prompts:
+        show:
+          other: Altri Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/nb.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/nb.yml
@@ -1,0 +1,30 @@
+nb:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Lag en ny Weigh In Prompt
+            reorder: Endre rekkefølgen på Weigh In Prompts
+            reorder_done: Ferdig å endre rekkefølgen Weigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: Beklager! Vi fant ikke noen resultater.
+            no_items_yet: Det er ingen Weigh In Prompts enda. Klikk på "Lag en ny Weigh In Prompt" for å legge til din første weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: Vis hvordan denne weigh in prompt ser ut offentlig <br/><em>(åpner i et nytt vindu)</em>
+            edit: Rediger denne weigh in prompt
+            delete: Fjern denne weigh in prompt permanent
+      weigh_in_prompts:
+        show:
+          other: Andre Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/nl.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/nl.yml
@@ -1,0 +1,30 @@
+nl:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Nieuwe Weigh In Prompt toevoegen
+            reorder: De volgorde van de Weigh In Prompts wijzigen
+            reorder_done: Klaar met het wijzingen van de van de Weigh In Prompt-volgorde
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: Helaas! Er zijn geen resultaten gevonden.
+            no_items_yet: Er zijn nog geen Weigh In Prompts. Druk op 'Nieuwe Weigh In Prompt toevoegen' om de eerste toe te voegen.
+          weigh_in_prompt:
+            view_live_html: Deze weigh in prompt op de website bekijken <br/><em>(opent in een nieuw venster)</em>
+            edit: Bewerk deze weigh in prompt
+            delete: Deze weigh in prompt definitief verwijderen
+      weigh_in_prompts:
+        show:
+          other: Andere Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/ru.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/ru.yml
@@ -1,0 +1,30 @@
+ru:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Добавить Weigh In Prompt
+            reorder: Изменить порядок Weigh In Prompts
+            reorder_done: Закончить изменять порядок Weigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: "Извините, поиск не дал результатов."
+            no_items_yet: Записей "Weigh In Prompts" не найдено. Нажмите "Добавить Weigh In Prompt" чтобы создать weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: Просмотреть weigh in prompt вживую <br/><em>(в новом окне)</em>
+            edit: Редактировать weigh in prompt
+            delete: Удалить weigh in prompt навсегда
+      weigh_in_prompts:
+        show:
+          other: Другие Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/sk.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/sk.yml
@@ -1,0 +1,30 @@
+sk:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Pridať Weigh In Prompt
+            reorder: Preusporiadať Weigh In Prompts
+            reorder_done: Koniec radenia Weigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: Ľutujeme, ale neboli nájdené žiadne výsledky.
+            no_items_yet: Nie sú vytvorené žiadne Weigh In Prompts. Kliknite na "Pridať Weigh In Prompt" pre pridanie prvého weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: Zobraziť náhľad weigh in prompt<br/><em>(otvorí sa v novom okne)</em>
+            edit: Upraviť weigh in prompt
+            delete: Zmazať weigh in prompt
+      weigh_in_prompts:
+        show:
+          other: Daľšie Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/tr.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/tr.yml
@@ -1,0 +1,30 @@
+tr:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: Yeni Ekle Weigh In Prompt
+            reorder: Tekrar sirala Weigh In Prompts
+            reorder_done: Tekrar siralama tamamlandiWeigh In Prompts
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: Uzgunum! Herhangi bir sonuc bulunamadi.
+            no_items_yet: Herhangi bir Weigh In Prompts yok henuz.  Tikla "Yeni Ekle Weigh In Prompt" eklemek senin ilk weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: Bunu canlu weigh in prompt goruntule <br/><em>(yeni bir pencerede acar)</em>
+            edit: Bunu Duzenle weigh in prompt
+            delete: Bunu Sil weigh in prompt sonsuza dek
+      weigh_in_prompts:
+        show:
+          other: Diger Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/locales/zh-CN.yml
+++ b/vendor/extensions/weigh_in_prompts/config/locales/zh-CN.yml
@@ -1,0 +1,32 @@
+zh-CN:
+  refinery:
+    plugins:
+      weigh_in_prompts:
+        title: Weigh In Prompts
+    weigh_in_prompts:
+      admin:
+        weigh_in_prompts:
+          actions:
+            create_new: 建立新的 Weigh In Prompt
+            reorder: 对 Weigh In Prompts 重新排序
+            reorder_done: 对 Weigh In Prompts 的重新排序结束
+          records:
+            title: Weigh In Prompts
+            sorry_no_results: 对不起，未找到结果。 #Sorry! There are no results found.
+
+            # There are no Weigh In Prompts yet. Click "Add New Weigh In Prompt" to add your first weigh in prompt.
+            no_items_yet: 目前没有 Weigh In Prompts . 点击 "Add New Weigh In Prompt" 创建一个weigh in prompt.
+          weigh_in_prompt:
+            view_live_html: 查看 weigh in prompt 的最新内容.<br/><em>(新窗口中打开)</em>
+            edit: 编辑 weigh in prompt
+            delete: 永久删除 weigh in prompt
+      weigh_in_prompts:
+        show:
+          other: 其他 Weigh In Prompts
+  activerecord:
+    attributes:
+      'refinery/weigh_in_prompts/weigh_in_prompt':
+        title: Title
+        image: Image
+        body: Body
+        style: Style

--- a/vendor/extensions/weigh_in_prompts/config/routes.rb
+++ b/vendor/extensions/weigh_in_prompts/config/routes.rb
@@ -1,0 +1,13 @@
+Refinery::Core::Engine.routes.draw do
+
+  # Admin routes
+  namespace :weigh_in_prompts, :path => '' do
+    namespace :admin, :path => Refinery::Core.backend_route do
+      resources :weigh_in_prompts, :except => :show do
+        collection do
+          post :update_positions
+        end
+      end
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/db/migrate/1_create_weigh_in_prompts_weigh_in_prompts.rb
+++ b/vendor/extensions/weigh_in_prompts/db/migrate/1_create_weigh_in_prompts_weigh_in_prompts.rb
@@ -1,0 +1,26 @@
+class CreateWeighInPromptsWeighInPrompts < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :refinery_weigh_in_prompts do |t|
+      t.string :title
+      t.integer :image_id
+      t.text :body
+      t.integer :style
+      t.integer :position
+
+      t.timestamps
+    end
+
+
+  end
+
+
+  def down
+    if defined?(::Refinery::UserPlugin)
+      ::Refinery::UserPlugin.destroy_all({:name => "refinerycms-weigh_in_prompts"})
+    end
+
+    drop_table :refinery_weigh_in_prompts
+
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/db/seeds.rb
+++ b/vendor/extensions/weigh_in_prompts/db/seeds.rb
@@ -1,0 +1,10 @@
+Refinery::I18n.frontend_locales.each do |lang|
+  I18n.locale = lang
+
+  Refinery::User.find_each do |user|
+    user.plugins.where(name: 'refinerycms-weigh_in_prompts').first_or_create!(
+      position: (user.plugins.maximum(:position) || -1) +1
+    )
+  end if defined?(Refinery::User)
+
+end

--- a/vendor/extensions/weigh_in_prompts/lib/generators/refinery/weigh_in_prompts_generator.rb
+++ b/vendor/extensions/weigh_in_prompts/lib/generators/refinery/weigh_in_prompts_generator.rb
@@ -1,0 +1,19 @@
+module Refinery
+  class WeighInPromptsGenerator < Rails::Generators::Base
+
+    def rake_db
+      rake "refinery_weigh_in_prompts:install:migrations"
+    end
+
+    def append_load_seed_data
+      create_file 'db/seeds.rb' unless File.exists?(File.join(destination_root, 'db', 'seeds.rb'))
+      append_file 'db/seeds.rb', :verbose => true do
+        <<-EOH
+
+# Added by Refinery CMS WeighInPrompts extension
+Refinery::WeighInPrompts::Engine.load_seed
+        EOH
+      end
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/lib/refinery/weigh_in_prompts.rb
+++ b/vendor/extensions/weigh_in_prompts/lib/refinery/weigh_in_prompts.rb
@@ -1,0 +1,21 @@
+require 'refinerycms-core'
+
+module Refinery
+  autoload :WeighInPromptsGenerator, 'generators/refinery/weigh_in_prompts_generator'
+
+  module WeighInPrompts
+    require 'refinery/weigh_in_prompts/engine'
+
+    class << self
+      attr_writer :root
+
+      def root
+        @root ||= Pathname.new(File.expand_path('../../../', __FILE__))
+      end
+
+      def factory_paths
+        @factory_paths ||= [ root.join('spec', 'factories').to_s ]
+      end
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/lib/refinery/weigh_in_prompts/engine.rb
+++ b/vendor/extensions/weigh_in_prompts/lib/refinery/weigh_in_prompts/engine.rb
@@ -1,0 +1,27 @@
+module Refinery
+  module WeighInPrompts
+    class Engine < Rails::Engine
+      extend Refinery::Engine
+      isolate_namespace Refinery::WeighInPrompts
+
+      engine_name :refinery_weigh_in_prompts
+
+      before_inclusion do
+        Refinery::Plugin.register do |plugin|
+          plugin.name = "weigh_in_prompts"
+          plugin.url = proc { Refinery::Core::Engine.routes.url_helpers.weigh_in_prompts_admin_weigh_in_prompts_path }
+          plugin.pathname = root
+
+        end
+      end
+
+      initializer "refinery_weigh_in_prompts.factories", after: "factory_bot.set_factory_paths" do
+        FactoryBot.definition_file_paths << File.expand_path('../../../../spec/support/factories/refinery', __FILE__) if defined?(FactoryBot)
+      end
+
+      config.after_initialize do
+        Refinery.register_extension(Refinery::WeighInPrompts)
+      end
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/lib/refinerycms-weigh_in_prompts.rb
+++ b/vendor/extensions/weigh_in_prompts/lib/refinerycms-weigh_in_prompts.rb
@@ -1,0 +1,1 @@
+require 'refinery/weigh_in_prompts'

--- a/vendor/extensions/weigh_in_prompts/lib/tasks/refinery/weigh_in_prompts.rake
+++ b/vendor/extensions/weigh_in_prompts/lib/tasks/refinery/weigh_in_prompts.rake
@@ -1,0 +1,13 @@
+namespace :refinery do
+
+  namespace :weigh_in_prompts do
+
+    # call this task by running: rake refinery:weigh_in_prompts:my_task
+    # desc "Description of my task below"
+    # task :my_task => :environment do
+    #   # add your logic here
+    # end
+
+  end
+
+end

--- a/vendor/extensions/weigh_in_prompts/readme.md
+++ b/vendor/extensions/weigh_in_prompts/readme.md
@@ -1,0 +1,10 @@
+# Weigh In Prompts extension for Refinery CMS.
+
+## How to build this extension as a gem (not required)
+
+    cd vendor/extensions/weigh_in_prompts
+    gem build refinerycms-weigh_in_prompts.gemspec
+    gem install refinerycms-weigh_in_prompts.gem
+
+    # Sign up for a https://rubygems.org/ account and publish the gem
+    gem push refinerycms-weigh_in_prompts.gem

--- a/vendor/extensions/weigh_in_prompts/refinerycms-weigh_in_prompts.gemspec
+++ b/vendor/extensions/weigh_in_prompts/refinerycms-weigh_in_prompts.gemspec
@@ -1,0 +1,20 @@
+# Encoding: UTF-8
+
+Gem::Specification.new do |s|
+  s.platform          = Gem::Platform::RUBY
+  s.name              = 'refinerycms-weigh_in_prompts'
+  s.version           = '1.0'
+  s.description       = 'Ruby on Rails Weigh In Prompts extension for Refinery CMS'
+  s.date              = '2019-04-25'
+  s.summary           = 'Weigh In Prompts extension for Refinery CMS'
+  s.authors           = ["Matthew Zagaja"]
+  s.require_paths     = %w(lib)
+  s.files             = Dir["{app,config,db,lib}/**/*"] + ["readme.md"]
+
+  # Runtime dependencies
+  s.add_dependency             'refinerycms-core',    '~> 4.0.2'
+  s.add_dependency             'acts_as_indexed',     '~> 0.8.0'
+
+  # Development dependencies (usually used for testing)
+  s.add_development_dependency 'refinerycms-testing', '~> 4.0.2'
+end

--- a/vendor/extensions/weigh_in_prompts/script/rails
+++ b/vendor/extensions/weigh_in_prompts/script/rails
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+
+ENGINE_PATH = File.expand_path('../..',  __FILE__)
+dummy_rails_path = File.expand_path('../../spec/dummy/script/rails',  __FILE__)
+if File.exist?(dummy_rails_path)
+  load dummy_rails_path
+else
+  puts "Please first run 'rake refinery:testing:dummy_app' to create a dummy Refinery CMS application."
+end

--- a/vendor/extensions/weigh_in_prompts/spec/features/refinery/weigh_in_prompts/admin/weigh_in_prompts_spec.rb
+++ b/vendor/extensions/weigh_in_prompts/spec/features/refinery/weigh_in_prompts/admin/weigh_in_prompts_spec.rb
@@ -1,0 +1,98 @@
+# encoding: utf-8
+require "spec_helper"
+
+describe Refinery do
+  describe "WeighInPrompts" do
+    describe "Admin" do
+      describe "weigh_in_prompts", type: :feature do
+        refinery_login
+
+        describe "weigh_in_prompts list" do
+          before do
+            FactoryBot.create(:weigh_in_prompt, :title => "UniqueTitleOne")
+            FactoryBot.create(:weigh_in_prompt, :title => "UniqueTitleTwo")
+          end
+
+          it "shows two items" do
+            visit refinery.weigh_in_prompts_admin_weigh_in_prompts_path
+            expect(page).to have_content("UniqueTitleOne")
+            expect(page).to have_content("UniqueTitleTwo")
+          end
+        end
+
+        describe "create" do
+          before do
+            visit refinery.weigh_in_prompts_admin_weigh_in_prompts_path
+
+            click_link "Add New Weigh In Prompt"
+          end
+
+          context "valid data" do
+            it "should succeed" do
+              fill_in "Title", :with => "This is a test of the first string field"
+              expect { click_button "Save" }.to change(Refinery::WeighInPrompts::WeighInPrompt, :count).from(0).to(1)
+
+              expect(page).to have_content("'This is a test of the first string field' was successfully added.")
+            end
+          end
+
+          context "invalid data" do
+            it "should fail" do
+              expect { click_button "Save" }.not_to change(Refinery::WeighInPrompts::WeighInPrompt, :count)
+
+              expect(page).to have_content("Title can't be blank")
+            end
+          end
+
+          context "duplicate" do
+            before { FactoryBot.create(:weigh_in_prompt, :title => "UniqueTitle") }
+
+            it "should fail" do
+              visit refinery.weigh_in_prompts_admin_weigh_in_prompts_path
+
+              click_link "Add New Weigh In Prompt"
+
+              fill_in "Title", :with => "UniqueTitle"
+              expect { click_button "Save" }.not_to change(Refinery::WeighInPrompts::WeighInPrompt, :count)
+
+              expect(page).to have_content("There were problems")
+            end
+          end
+
+        end
+
+        describe "edit" do
+          before { FactoryBot.create(:weigh_in_prompt, :title => "A title") }
+
+          it "should succeed" do
+            visit refinery.weigh_in_prompts_admin_weigh_in_prompts_path
+
+            within ".actions" do
+              click_link "Edit this weigh in prompt"
+            end
+
+            fill_in "Title", :with => "A different title"
+            click_button "Save"
+
+            expect(page).to have_content("'A different title' was successfully updated.")
+            expect(page).not_to have_content("A title")
+          end
+        end
+
+        describe "destroy" do
+          before { FactoryBot.create(:weigh_in_prompt, :title => "UniqueTitleOne") }
+
+          it "should succeed" do
+            visit refinery.weigh_in_prompts_admin_weigh_in_prompts_path
+
+            click_link "Remove this weigh in prompt forever"
+
+            expect(page).to have_content("'UniqueTitleOne' was successfully removed.")
+            expect(Refinery::WeighInPrompts::WeighInPrompt.count).to eq(0)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/spec/models/refinery/weigh_in_prompts/weigh_in_prompt_spec.rb
+++ b/vendor/extensions/weigh_in_prompts/spec/models/refinery/weigh_in_prompts/weigh_in_prompt_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module Refinery
+  module WeighInPrompts
+    describe WeighInPrompt do
+      describe "validations", type: :model do
+        subject do
+          FactoryBot.create(:weigh_in_prompt,
+          :title => "Refinery CMS")
+        end
+
+        it { should be_valid }
+        its(:errors) { should be_empty }
+        its(:title) { should == "Refinery CMS" }
+      end
+    end
+  end
+end

--- a/vendor/extensions/weigh_in_prompts/spec/spec_helper.rb
+++ b/vendor/extensions/weigh_in_prompts/spec/spec_helper.rb
@@ -1,0 +1,30 @@
+# Configure Rails Environment
+ENV["RAILS_ENV"] ||= 'test'
+
+if File.exist?(dummy_path = File.expand_path('../dummy/config/environment.rb', __FILE__))
+  require dummy_path
+elsif File.dirname(__FILE__) =~ %r{vendor/extensions}
+  # Require the path to the refinerycms application this is vendored inside.
+  require File.expand_path('../../../../../config/environment', __FILE__)
+else
+  puts "Could not find a config/environment.rb file to require. Please specify this in #{File.expand_path(__FILE__)}"
+end
+
+require 'rspec/rails'
+require 'capybara/rspec'
+
+Rails.backtrace_cleaner.remove_silencers!
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+end
+
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories including factories.
+([Rails.root.to_s] | ::Refinery::Plugins.registered.pathnames).map{ |p|
+  Dir[File.join(p, 'spec', 'support', '**', '*.rb').to_s]
+}.flatten.sort.each do |support_file|
+  require support_file
+end

--- a/vendor/extensions/weigh_in_prompts/spec/support/factories/refinery/weigh_in_prompts.rb
+++ b/vendor/extensions/weigh_in_prompts/spec/support/factories/refinery/weigh_in_prompts.rb
@@ -1,0 +1,10 @@
+
+FactoryBot.define do
+  factory :weigh_in_prompt, :class => Refinery::WeighInPrompts::WeighInPrompt do
+    sequence(:title) { |n| "WeighInPrompt#{n}" }
+    body { "Share what you want the region to be like in 2050!" }
+    style { :large }
+    image
+  end
+end
+

--- a/vendor/extensions/weigh_in_prompts/tasks/rspec.rake
+++ b/vendor/extensions/weigh_in_prompts/tasks/rspec.rake
@@ -1,0 +1,6 @@
+require 'rspec/core/rake_task'
+
+desc "Run specs"
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "./spec"
+end

--- a/vendor/extensions/weigh_in_prompts/tasks/testing.rake
+++ b/vendor/extensions/weigh_in_prompts/tasks/testing.rake
@@ -1,0 +1,8 @@
+namespace :refinery do
+  namespace :testing do
+    # Put any code in here that you want run when you test this extension against a dummy app.
+    # For example, the call to require your gem and start your generator.
+    task :setup_extension do
+    end
+  end
+end


### PR DESCRIPTION
# Why is this change necessary?
Our design calls for prompts in the list of stories in Weigh In that have unique background images.

# How does it address the issue?
It provides a refinery extension with an administrative interface so that an administrator can add new Weigh In Prompts as the need for them arises.
