### PR TITLE
Bjs/weigh in grid mobile style

### DIFF
--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -193,19 +193,17 @@
 
     &--response {
       background: $v3_color_weigh-in-response-bg;
-      color: $v3_color_bg-lightest;
       font-size: $font_size-small;
       height: 20rem;
       padding: 2.7rem;
       width: 24rem;
 
-      &-text {
+      &-text a {
+        color: $v3_color_bg-lightest;
         height: 11rem;
         margin: 0;
-        overflow: hidden;
-        text-overflow: ellipsis;
-        white-space: wrap;
-        width: 18rem;
+        text-decoration: none;
+        width: 18.95rem;
       }
 
       @include media(small) {
@@ -217,10 +215,7 @@
         width: 11.9rem;
 
         &-text {
-          height: 2rem;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
+          height: auto;
           width: 9rem;
         }
       }

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -22,8 +22,8 @@
 
     @include media(small) {
       grid-template-columns: auto;
-      margin: initial;
-      padding: 3.75rem 1rem 0;
+      margin: 0 2.6rem 1.5rem .95rem;
+      padding: 3.75rem 0 0;
     }
 
     display: grid;
@@ -104,6 +104,9 @@
     &.container {
       @include media(medium) {
         flex-wrap: nowrap;
+        height: auto;
+        padding: 0;
+        width: 11.9rem;
       }
 
       align-content: center;
@@ -115,6 +118,10 @@
   }
 
   .story {
+    @include media(small) {
+      margin-bottom: 1rem;
+    }
+
     margin: 0 2.5rem 2.5rem 0;
 
     &+.story-meta {
@@ -125,6 +132,14 @@
     }
 
     &--prompt-small {
+      @include media(small) {
+        font-size: $v3_font_size-event-title-mobile;
+        height: 3.75rem;
+        margin-bottom: 1rem;
+        padding: 1rem;
+        width: 11.9rem;
+      }
+
       background: $v3-color_green-dark;
       font-size: $font_size-large;
       height: 7.5rem;
@@ -139,6 +154,15 @@
     }
 
     &--prompt-large {
+      @include media(small) {
+        color: $v3-color_green-dark;
+        font-size: $v3_font_size-event-title-mobile;
+        height: 3.75rem;
+        margin-bottom: 1rem;
+        padding: 1rem;
+        width: 11.9rem;
+      }
+
       background-image: image-url('middlesex-fells-credit-paul-w.jpg');
       font-size: $font_size-xlarge;
       height: 20rem;
@@ -147,6 +171,19 @@
       text-align: center;
       vertical-align: middle;
       width: 24rem;
+
+      &-text {
+        @include media(small) {
+          color: $v3_color_bg-lightest;
+          font-size: $font_size-small;
+          line-height: 1em;
+          margin: 0;
+          padding: 0;
+        }
+
+        color: $v3_color_bg-lightest;
+        font-size: $font_size-xlarge;
+      }
 
       &:hover {
         cursor: pointer;
@@ -158,19 +195,63 @@
       color: $v3_color_bg-lightest;
       font-size: $font_size-small;
       height: 20rem;
-      overflow: hidden;
-      padding: 2.5rem;
-      text-overflow: ellipsis;
-      white-space: wrap;
+      padding: 2.7rem;
       width: 24rem;
+
+      &-text {
+        height: 11rem;
+        margin: 0;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: wrap;
+        width: 18rem;
+      }
+
+      @include media(small) {
+        direction: ltr;
+        display: inline-block;
+        font-size: 12px;
+        height: 3.75rem;
+        padding: .6rem;
+        width: 11.9rem;
+
+        &-text {
+          height: 2rem;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+          width: 9rem;
+        }
+      }
     }
 
     &__response--submitter-name {
+      @include media(small) {
+        margin: 0 .3rem .01rem 0;
+        padding: 0;
+      }
+
       color: $v3_color_bg-lightest;
       text-align: right;
-  }
+    }
 
     &--video {
+      @include media(medium) {
+        height: 10rem;
+        padding: 17px 23px 17px 28px;
+        width: 11.9rem;
+
+        video {
+          height: 10rem;
+          left: 0;
+          max-width: initial;
+          object-fit: cover;
+          position: absolute;
+          top: 0;
+          width: 11.9rem;
+        }
+      }
+
       height: 20rem;
       overflow: hidden;
       width: 24rem;
@@ -279,6 +360,13 @@
 
   .media-player {
     &__audio {
+      @include media(small) {
+        height: 3.75rem;
+        margin: 0;
+        padding: 0;
+        width: 11.9rem;
+      }
+
       background-color: $v3-color_slate;
       display: grid;
       grid-template-columns: 60px 1fr;
@@ -287,11 +375,17 @@
     }
 
     &__pause-play {
+      @include media(small) {
+        height: 1rem;
+        margin: 1rem 0 0 1rem;
+        width: 1rem;
+      }
+
       background: no-repeat image-url('play-icon.svg');
       background-size: contain;
       grid-column: 1;
-      height: 28px;
-      width: 28px;
+      height: 1.4rem;
+      width: 1.4rem;
     }
 
     &__pause-play--playing {
@@ -300,12 +394,24 @@
     }
 
     &__speaker {
+      @include media(small) {
+        font-size: $font_size-xsmall;
+        margin: 0;
+        padding: 0;
+      }
+
       color: $color_font-grey;
       font-style: italic;
       grid-column: 2;
     }
 
     &__question-text {
+      @include media(small) {
+        font-size: 1rem;
+        margin-top: .5rem;
+        padding: 0;
+      }
+
       color: $v3-color_light-blue;
       font-size: 1.4rem;
       grid-column: 2;
@@ -314,6 +420,12 @@
     }
 
     &__progress {
+      @include media(small) {
+        height: .1rem;
+        margin-top: 0;
+        width: 50%;
+      }
+
       background-color: $v3-color_green-lightest;
       grid-column: 2;
       height: .2rem;
@@ -329,6 +441,10 @@
     }
 
     &__time {
+      @include media(small) {
+        display: none;
+      }
+
       color: $color_font-grey;
       grid-column: 2;
       justify-self: end;

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -122,7 +122,8 @@
       margin-bottom: 1rem;
     }
 
-    margin: 0 2.5rem 2.5rem 0;
+    margin-bottom: 2.5rem;
+    margin-right: 2.5rem;
 
     &+.story-meta {
       color: $color_green-dark;

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -179,6 +179,7 @@
           line-height: 1em;
           margin: 0;
           padding: 0;
+          text-decoration: none;
         }
 
         color: $v3_color_bg-lightest;

--- a/app/javascript/packs/goals-survey.js
+++ b/app/javascript/packs/goals-survey.js
@@ -24,7 +24,7 @@ const weighInGoalsLink = () => {
     if (document.documentElement.clientWidth > 770) {
       openGoals()
     } else {
-      openGoalsInNewTab(event.currentTarget.href);
+      openGoalsInNewTab(this.children[0]["href"]);
     }
   })
 }
@@ -32,6 +32,7 @@ const weighInGoalsLink = () => {
 const oneBoxGoalsLink = () => {
   $('a').on('click', (event) => {
     event.preventDefault();
+    event.stopPropagation();
     if (document.documentElement.clientWidth > 770 && event.currentTarget.href == goalsSurveyLink) {
       openGoals()
     } else {

--- a/app/javascript/packs/response-text.js
+++ b/app/javascript/packs/response-text.js
@@ -1,0 +1,48 @@
+window.addEventListener('load', () => {
+  storeAllStoryTexts()
+  lineClampResponseTexts()
+  window.addEventListener('resize', lineClampResponseTexts);
+
+  function storeAllStoryTexts() {
+    $.get({
+      url: '/stories',
+      dataType: 'json'
+    }).done(res = function (res) {
+      res.forEach(story => {
+        if (story.data.attributes.response.length > 0) {
+          window.localStorage.setItem(`story${story.data.id}`, story.data.attributes.response.replace(/<p>|<\/p>/, ''))
+        }
+      })
+    })
+  }
+
+  function lineClampResponseTexts() {
+    if (document.documentElement.clientWidth > 770) {
+      reloadStoryTexts()
+      console.log("over 770")
+      $('div.story--response-text').succinct({
+        size: 400,
+        omission: '...',
+        ignore: false
+      });
+    } else if (document.documentElement.clientWidth < 770) {
+      console.log("under 770")
+      $('div.story--response-text').succinct({
+        size: 45,
+        omission: '...',
+        ignore: false
+      });
+    }
+  }
+
+  function reloadStoryTexts() {
+    if (document.documentElement.clientWidth > 770) {
+      Array.from($('.story--response')).forEach(div => {
+        if (div.children[0].children[0]) {
+          div.children[0].children[0].innerText = window.localStorage.getItem(`${div.id}`)
+        }
+      })
+    }
+  }
+
+});

--- a/app/javascript/packs/succinct.js
+++ b/app/javascript/packs/succinct.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2014 Mike King (@micjamking)
+ *
+ * jQuery Succinct plugin
+ * Version 1.1.0 (October 2014)
+ *
+ * Licensed under the MIT License
+ */
+
+/*global jQuery*/
+(function ($) {
+  'use strict';
+  console.log("succint loaded ...")
+
+  $.fn.succinct = function (options) {
+
+    var settings = $.extend({
+      size: 240,
+      omission: '...',
+      ignore: true
+    }, options);
+
+    return this.each(function () {
+
+      var textDefault,
+        textTruncated,
+        elements = $(this),
+        regex = /[!-\/:-@\[-`{-~]$/,
+        init = function () {
+          elements.each(function () {
+            textDefault = $(this).html();
+
+            if (textDefault.length > settings.size) {
+              textTruncated = $.trim(textDefault)
+                .substring(0, settings.size)
+                .split(' ')
+                .slice(0, -1)
+                .join(' ');
+
+              if (settings.ignore) {
+                textTruncated = textTruncated.replace(regex, '');
+              }
+
+              $(this).html(textTruncated + settings.omission);
+            }
+          });
+        };
+      init();
+    });
+  };
+})(jQuery);

--- a/vendor/extensions/stories/app/controllers/refinery/stories/stories_controller.rb
+++ b/vendor/extensions/stories/app/controllers/refinery/stories/stories_controller.rb
@@ -3,20 +3,29 @@ module Refinery
     class StoriesController < ::ApplicationController
 
       before_action :find_all_stories
-      before_action :find_page
+      # before_action :find_page
 
       def index
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @story in the line below:
-        present(@page)
+        stories = Refinery::Stories::Story.all.map {|story| StorySerializer.new(story).serializable_hash}
+
+        respond_to do |format|
+          format.html { present(@page) }
+          format.json { render json: stories }
+        end
       end
 
       def show
         @story = Story.find(params[:id])
-
         # you can use meta fields from your model instead (e.g. browser_title)
         # by swapping @page for @story in the line below:
-        present(@page)
+        story = StorySerializer.new(@story).serializable_hash
+        
+        respond_to do |format|
+          format.html { present(@page) }
+          format.json { render json: story }
+        end
       end
 
       def edit

--- a/vendor/extensions/stories/app/serializers/story_serializer.rb
+++ b/vendor/extensions/stories/app/serializers/story_serializer.rb
@@ -1,0 +1,4 @@
+class StorySerializer
+  include FastJsonapi::ObjectSerializer
+  attributes :title, :submitter_name, :question, :position, :display, :response, :video, :audio
+end

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
@@ -16,7 +16,9 @@
     </div>
   <% elsif media.response.present? %>
     <div class="story--response">
-      &ldquo;<%= media.response %>&rdquo;
+      <div class="story--response-text">
+        &ldquo;<%= strip_tags(media.response) %>&rdquo;
+      </div>
       <p class="story__response--submitter-name">- <%= media.submitter_name %></p>
     </div>
   <% else %>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
@@ -15,9 +15,9 @@
       <div class="media-player__time">0:00</div>
     </div>
   <% elsif media.response.present? %>
-    <div class="story--response">
+    <div id="story<%= media.id %>" class="story--response">
       <div class="story--response-text">
-        &ldquo;<%= strip_tags(media.response) %>&rdquo;
+        <a href="/stories/<%= media.id %>">&ldquo;<%= strip_tags(media.response) %>&rdquo;</a>
       </div>
       <p class="story__response--submitter-name">- <%= media.submitter_name %></p>
     </div>

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
@@ -1,6 +1,6 @@
 <% if prompt == "large" %>
   <div class="story--prompt-large">
-    <p class="story--prompt-large-text">MetroCommon Goals: What do you think?</p>
+    <a href="https://mapc.az1.qualtrics.com/jfe/form/SV_832YVvNk2Yabzox" class="story--prompt-large-text">MetroCommon Goals: What do you think?</a>
   </div>
 <% else %>
   <div class="story--prompt-small">

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_prompt.html.erb
@@ -1,6 +1,6 @@
 <% if prompt == "large" %>
   <div class="story--prompt-large">
-    <h1>MetroCommon Goals: What do you think?</h1>
+    <p class="story--prompt-large-text">MetroCommon Goals: What do you think?</p>
   </div>
 <% else %>
   <div class="story--prompt-small">

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/index.html.erb
@@ -2,6 +2,8 @@
   <%= javascript_pack_tag 'stories/index' %>
   <%= javascript_pack_tag 'weigh-in-grid' %>
   <%= javascript_pack_tag 'goals-survey' %>
+  <%= javascript_pack_tag 'succinct' %>
+  <%= javascript_pack_tag 'response-text' %>
 <% end %>
 
 <div class="StoriesPage">


### PR DESCRIPTION
This is getting closer. 

There are now styles for the weigh-in grid at mobile size. 

Outstanding issues: 

1. The margins for full screen (100rem at 80%) and mobile (25rem at 80%).
These are supposedly inherent in the XD file, but I have heard them referenced in various ways, against various objects on the design, at various screen widths, at various meetings. 

2. The proportions of video size from full screen to mobile size. We need written instructions for this, because I cannot remember all of the nuances that happen in the meetings.

3. The ellipsis functionality is almost there in terms of display in mobile size. The full width size seems to be infected by the properties I see for the mobile size, so it may be that a 2nd set of eyes will expose the problem in this code: 
```
     &--response {
      background: $v3_color_weigh-in-response-bg;
      color: $v3_color_bg-lightest;
      font-size: $font_size-small;
      height: 20rem;
      padding: 2.7rem;
      width: 24rem;

      &-text {
        height: 11rem;
        margin: 0;
        overflow: hidden;
        text-overflow: ellipsis;
        white-space: wrap;
        width: 18rem;
      }

      @include media(small) {
        direction: ltr;
        display: inline-block;
        font-size: 12px;
        height: 3.75rem;
        padding: .6rem;
        width: 11.9rem;

        &-text {
          height: 2rem;
          overflow: hidden;
          text-overflow: ellipsis;
          white-space: nowrap;
          width: 9rem;
        }
      }
    }
```

4. After the above are solved, next is the click behavior of the various items. 

5. The height calculations in mobile, still needs work and I think I'll be able to dial it in, so please over look the huge gap between the mobile view of stories and the footer, it will be addressed. 


