### PR TITLE
Resolve #304 Flexbox Height Calculation

### DIFF
--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -136,7 +136,6 @@
       @include media(small) {
         font-size: $v3_font_size-event-title-mobile;
         height: 3.75rem;
-        margin-bottom: 0;
         padding: 1rem;
         width: 11.9rem;
       }
@@ -144,7 +143,6 @@
       background: $v3-color_green-dark;
       font-size: $font_size-large;
       height: 7.5rem;
-      margin-bottom: 2.5rem;
       padding: 1.75rem 2.8rem;
       width: 24rem;
 

--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -162,11 +162,11 @@
         width: 11.9rem;
       }
 
+      display: flex;
       font-size: $font_size-xlarge;
       height: 20rem;
-      margin-bottom: 2.5rem;
-      padding-top: 6rem;
-      text-align: center;
+      padding: 2.7rem;
+      text-align: left;
       vertical-align: middle;
       width: 24rem;
 
@@ -175,13 +175,12 @@
           color: $v3_color_bg-lightest;
           font-size: $font_size-small;
           line-height: 1rem;
-          margin: 0;
           padding: 0;
           text-decoration: none;
         }
-
         color: $v3_color_bg-lightest;
         font-size: $font_size-xlarge;
+        margin: auto;
       }
 
       &:hover {

--- a/app/javascript/packs/weigh-in-grid.js
+++ b/app/javascript/packs/weigh-in-grid.js
@@ -1,38 +1,42 @@
-window.addEventListener('load', () => {
-  let totalHeight = 0;
+function calculateHeight(container) {
+  const children = Array.from(container.children);
+  const clientWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
+  const storyStyles = window.getComputedStyle(document.querySelector('.story'));
+  const containerStyles = window.getComputedStyle(container);
+  const storyMarginBottom = parseInt(storyStyles.getPropertyValue('margin-bottom'), 10);
+  const paddingTopAndBottom = parseInt(containerStyles.getPropertyValue('padding-top'), 10) + parseInt(containerStyles.getPropertyValue('padding-bottom'), 10);
+  const totalHeight = children.reduce((height, child) => height + child.clientHeight + storyMarginBottom, 0);
+
+  let columns = 3;
+  if (clientWidth < 960) {
+    columns = 1;
+  } else if (clientWidth < 1280) {
+    columns = 2;
+  }
+  // if totalHeight doesn't evenly divide into boxes, round up to next box of height
+  const bonusHeight = Math.round(360 - ((totalHeight / columns) % 360)) + paddingTopAndBottom;
+
+  if (columns === 1) {
+    return Math.round(totalHeight / columns);
+  }
+  return Math.round(totalHeight / columns) + bonusHeight;
+}
+
+function updateContainerHeight() {
   const container = document.getElementById('stories');
+  container.style.height = `${calculateHeight(container)}px`;
+}
 
-  function setContainerWidth() {
-    totalHeight = 0;
-    for (let i = 0; i < container.children.length; i += 1) {
-      if (container.children[i].children[0].classList.contains('story--audio')) {
-        totalHeight += 10;
-      } else if (container.children[i].classList.contains('story--prompt-small')) {
-        totalHeight += 10;
-      } else {
-        totalHeight += 22.5;
-      }
-      container.style.height = `${(Math.round(totalHeight / 3))}rem`;
-    }
-  }
+function responseLinks() {
+  $('.story--response-text').on('click', (event) => {
+    event.preventDefault();
+    window.location.href = event.currentTarget.firstElementChild.attributes.href.value;
+    window.history.pushState({}, '/stories', '/stories.html');
+  });
+}
 
-  function setContainerHeight() {
-    if (document.documentElement.clientWidth < 1350) {
-      totalHeight += 10;
-      container.style.height = `${(Math.round(totalHeight / 3) + 25)}rem`;
-    } else if (document.documentElement.clientWidth > 600) {
-      setContainerWidth();
-    }
-  }
-
-  function responseLinks() {
-    $('.story--response-text').on('click', (event) => {
-      event.preventDefault();
-      window.location.href = event.currentTarget.firstElementChild.attributes.href.value;
-      window.history.pushState({}, '/stories', '/stories.html');
-    });
-  }
-  window.addEventListener('resize', setContainerHeight);
-  setContainerWidth();
+window.addEventListener('load', () => {
+  window.addEventListener('resize', updateContainerHeight);
+  updateContainerHeight();
   responseLinks();
 });

--- a/spec/system/weigh_in_stories_spec.rb
+++ b/spec/system/weigh_in_stories_spec.rb
@@ -1,0 +1,12 @@
+require 'rails_helper'
+
+RSpec.describe 'Weigh In Stories', :type => :system do
+  it 'sizes flexbox container correctly with 4 objects', js: :true do
+    create(:story, :with_video)
+    create_list(:story, 2)
+    create(:weigh_in_prompt, style: 'small')
+    visit '/stories'
+    Capybara.current_session.driver.browser.manage.window.resize_to(1281, 1000)
+    expect(page).to have_xpath('//section[@id="stories"][@style="height: 784px;"]')
+  end
+end


### PR DESCRIPTION
The height of our flexbox container was not correctly calculating in the case where we had four boxes and one was a half height box. This commit refactors the weigh in grid javascript to calculate the height of the grid in pixels and round it up to the nearest box height to avoid 4 column layouts.
