### PR TITLE
Bjs/fix ellipsis

### DIFF
--- a/app/assets/stylesheets/refinery/stories.scss
+++ b/app/assets/stylesheets/refinery/stories.scss
@@ -106,7 +106,7 @@
         flex-wrap: nowrap;
         height: auto;
         padding: 0;
-        width: 11.9rem;
+        width: 15rem;
       }
 
       align-content: center;
@@ -120,10 +120,11 @@
   .story {
     @include media(small) {
       margin-bottom: 1rem;
+      width: 15rem;
     }
-
     margin-bottom: 2.5rem;
     margin-right: 2.5rem;
+    width: 24rem;
 
     &+.story-meta {
       color: $color_green-dark;
@@ -137,14 +138,12 @@
         font-size: $v3_font_size-event-title-mobile;
         height: 3.75rem;
         padding: 1rem;
-        width: 11.9rem;
       }
 
       background: $v3-color_green-dark;
       font-size: $font_size-large;
       height: 7.5rem;
       padding: 1.75rem 2.8rem;
-      width: 24rem;
 
       a {
         color: $v3_color_bg-lightest;
@@ -159,7 +158,6 @@
         height: 3.75rem;
         margin-bottom: 0;
         padding: 1rem;
-        width: 11.9rem;
       }
 
       display: flex;
@@ -168,7 +166,6 @@
       padding: 2.7rem;
       text-align: left;
       vertical-align: middle;
-      width: 24rem;
 
       &-text {
         @include media(small) {
@@ -193,14 +190,13 @@
       font-size: $font_size-small;
       height: 20rem;
       padding: 2.7rem;
-      width: 24rem;
+      width: 100%;
 
       &-text {
         color: $v3_color_bg-lightest;
         height: 11rem;
         margin: 0;
         text-decoration: none;
-        width: 18.95rem;
 
         &:hover {
           cursor: pointer;
@@ -213,11 +209,9 @@
         font-size: 12px;
         height: 3.75rem;
         padding: .6rem;
-        width: 11.9rem;
 
         &-text {
           height: auto;
-          width: 9rem;
         }
       }
     }
@@ -236,7 +230,7 @@
       @include media(small) {
         height: 10rem;
         padding: 17px 23px 17px 28px;
-        width: 11.9rem;
+        width: 15rem;
 
         video {
           height: 10rem;
@@ -361,14 +355,12 @@
         height: 3.75rem;
         margin: 0;
         padding: 0;
-        width: 11.9rem;
       }
 
       background-color: $v3-color_slate;
       display: grid;
       grid-template-columns: 60px 1fr;
       padding: 2rem;
-      width: 23.95rem;
     }
 
     &__pause-play {

--- a/app/javascript/packs/response-text.js
+++ b/app/javascript/packs/response-text.js
@@ -5,22 +5,20 @@ window.addEventListener('load', () => {
       dataType: 'json',
     }).done((res) => {
       res.forEach((story) => {
-        if (story.data.attributes.response.length > 0) {
-          window.localStorage.setItem(`story${story.data.id}`, story.data.attributes.response.replace(/<p>|<\/p>/, ''));
+        if (story.data.attributes.text_response) {
+          window.localStorage.setItem(`story${story.data.id}`, story.data.attributes.sanitized_response);
         }
       });
     });
   }
 
   function reloadStoryTexts() {
-    if (document.documentElement.clientWidth > 670) {
-      Array.from($('.story--response')).forEach((div) => {
-        if (div.children[0].children[0]) {
-          const modifiedDiv = div.children[0].children[0];
-          modifiedDiv.innerText = window.localStorage.getItem(`${div.id}`);
-        }
-      });
-    }
+    Array.from($('.story--response')).forEach((div) => {
+      if (div.children[0].children[0]) {
+        const modifiedDiv = div.children[0].children[0];
+        modifiedDiv.innerText = window.localStorage.getItem(`${div.id}`);
+      }
+    });
   }
 
   function lineClampResponseTexts() {
@@ -33,7 +31,7 @@ window.addEventListener('load', () => {
       });
     } else if (document.documentElement.clientWidth < 670) {
       $('div.story--response-text').succinct({
-        size: 45,
+        size: 55,
         omission: '...',
         ignore: false,
       });
@@ -41,6 +39,8 @@ window.addEventListener('load', () => {
   }
 
   storeAllStoryTexts();
-  lineClampResponseTexts();
+  setTimeout(function () {
+    lineClampResponseTexts();
+  }, 500);
   window.addEventListener('resize', lineClampResponseTexts);
 });

--- a/vendor/extensions/one_boxes/lib/import/one_box_seed.csv
+++ b/vendor/extensions/one_boxes/lib/import/one_box_seed.csv
@@ -1,6 +1,6 @@
 title,visible,triangle_overlay,image_file_name,link,,
 Find Out,TRUE,FALSE,190306MCBOS004.png,/find-out,,
-Weigh In,TRUE,FALSE,190306MCBOS161.png,/stories/new,,
+Weigh In,TRUE,FALSE,190306MCBOS161.png,/stories,,
 Voices from the Region,TRUE,FALSE,190228MCFram219.png,/stories,,
 Process Timeline,TRUE,FALSE,190306MCBOS123.png,/process-details,,
 Goals Feedback,TRUE,FALSE,mc50_norwood-42.png,/goals,,

--- a/vendor/extensions/stories/app/models/refinery/stories/story.rb
+++ b/vendor/extensions/stories/app/models/refinery/stories/story.rb
@@ -25,6 +25,10 @@ module Refinery
         end
       end
 
+      def text_response
+        !audio.attached? && !video.attached?
+      end
+
       private
       def create_transcript
         if response.blank? && !audio.attached? && video.attached?

--- a/vendor/extensions/stories/app/serializers/story_serializer.rb
+++ b/vendor/extensions/stories/app/serializers/story_serializer.rb
@@ -1,4 +1,8 @@
 class StorySerializer
   include FastJsonapi::ObjectSerializer
-  attributes :title, :submitter_name, :question, :position, :display, :response, :video, :audio
+  attributes :title, :submitter_name, :question, :position, :display, :response, :video, :audio, :text_response
+
+  attribute :sanitized_response do |story|
+    ActionController::Base.helpers.strip_tags(story.response)
+  end
 end


### PR DESCRIPTION
Resolves issues with Ellipses, Mobile Width, Homepage weigh-in link and page initial load.

# Why is this change necessary?
Ellipses functionality was working conditionally for long text.
Initial load was not populating response texts except for special conditions.
Mobile Width too narrow, and needed to be set by a higher level container.
Home page weigh-in link was pointing to /stories/new

# How does it address the issue?
Ellipses functions 500ms later, allowing Rails view to load page.
CSS updated to set story width in story container.
Updated CSV file for one-box seed, to provide homepage weigh-in link to:  /stories

# What side effects does it have?
None.