### PR TITLE
Resolve #310 IE One Box Bug

### DIFF
--- a/app/assets/stylesheets/components/grid.scss
+++ b/app/assets/stylesheets/components/grid.scss
@@ -3,11 +3,13 @@
 
   &--3-2 {
     grid-template-columns: 1fr 1fr 1fr;
+    grid-template-rows: 1fr 1fr;
     grid-gap: 3.15rem;
 
 
     @include media(medium) {
       grid-template-columns: 1fr 1fr;
+      grid-template-rows: 1fr 1fr 1fr;
       grid-auto-rows: 4.25rem;
       grid-gap: .9rem;
     }


### PR DESCRIPTION
This commit fixes the bug where the one boxes were overlapping in IE11 by defining grid-template-row attributes on the 3-2 grid so that the grid because IE does not support grid-auto-rows. It requires grid-template-rows to appropriately lay out the one box grid.