### PR TITLE
Resolve #316 Question Helper Text

### DIFF
--- a/vendor/extensions/stories/app/helpers/refinery/stories/stories_helper.rb
+++ b/vendor/extensions/stories/app/helpers/refinery/stories/stories_helper.rb
@@ -12,9 +12,9 @@ module Refinery
       end
 
       def audio_question_text(enum)
-        if enum === 'question1'
+        if enum === 'question2'
           'In 2050...'
-        elsif enum === 'question2'
+        elsif enum === 'question1'
           'Ask the Future'
         else
           'No question was selected.'


### PR DESCRIPTION
Reverse the audio question text helper to display the correct audio question text prompt based on the selected question.
