### PR TITLE
Bjs/js fixes 190503

### DIFF
--- a/app/javascript/packs/goals-survey.js
+++ b/app/javascript/packs/goals-survey.js
@@ -4,7 +4,7 @@ $(() => {
   oneBoxGoalsLink();
 })
 
-const goalsSurveyLink = "https://mapc.az1.qualtrics.com/jfe/form/SV_832YVvNk2Yabzox"
+const goalsSurveyLink = "https://mapc.az1.qualtrics.com/jfe/form/SV_b2t2u5mm1CkeFV3"
 
 const announcementGoalsLink = () => {
   $("body").on('click', 'a.button.announcements__button', function (event) {

--- a/app/javascript/packs/response-text.js
+++ b/app/javascript/packs/response-text.js
@@ -1,17 +1,4 @@
-window.addEventListener('load', () => {
-  function storeAllStoryTexts() {
-    $.get({
-      url: '/stories',
-      dataType: 'json',
-    }).done((res) => {
-      res.forEach((story) => {
-        if (story.data.attributes.text_response) {
-          window.localStorage.setItem(`story${story.data.id}`, story.data.attributes.sanitized_response);
-        }
-      });
-    });
-  }
-
+$(() => {
   function reloadStoryTexts() {
     Array.from($('.story--response')).forEach((div) => {
       if (div.children[0].children[0]) {
@@ -22,8 +9,8 @@ window.addEventListener('load', () => {
   }
 
   function lineClampResponseTexts() {
+    reloadStoryTexts();
     if (document.documentElement.clientWidth > 670) {
-      reloadStoryTexts();
       $('div.story--response-text').succinct({
         size: 400,
         omission: '...',
@@ -38,9 +25,19 @@ window.addEventListener('load', () => {
     }
   }
 
+  function storeAllStoryTexts() {
+    $.get({
+      url: '/stories',
+      dataType: 'json',
+    }).done((res) => {
+      res.forEach((story) => {
+        if (story.data.attributes.text_response) {
+          window.localStorage.setItem(`story${story.data.id}`, story.data.attributes.sanitized_response);
+        }
+      });
+      lineClampResponseTexts();
+    });
+  }
   storeAllStoryTexts();
-  setTimeout(function () {
-    lineClampResponseTexts();
-  }, 500);
   window.addEventListener('resize', lineClampResponseTexts);
 });

--- a/app/javascript/packs/weigh-in-grid.js
+++ b/app/javascript/packs/weigh-in-grid.js
@@ -6,6 +6,7 @@ function calculateHeight(container) {
   const storyMarginBottom = parseInt(storyStyles.getPropertyValue('margin-bottom'), 10);
   const paddingTopAndBottom = parseInt(containerStyles.getPropertyValue('padding-top'), 10) + parseInt(containerStyles.getPropertyValue('padding-bottom'), 10);
   const totalHeight = children.reduce((height, child) => height + child.clientHeight + storyMarginBottom, 0);
+  let bonusHeight = 0;
 
   let columns = 3;
   if (clientWidth < 960) {
@@ -13,8 +14,10 @@ function calculateHeight(container) {
   } else if (clientWidth < 1280) {
     columns = 2;
   }
-  // if totalHeight doesn't evenly divide into boxes, round up to next box of height
-  const bonusHeight = Math.round(360 - ((totalHeight / columns) % 360)) + paddingTopAndBottom;
+  // if totalHeight doesn't evenly divide into boxes, add 360 to bonusHeight;
+  if (Math.round(360 - ((totalHeight / columns) % 360 !== 0))) {
+    bonusHeight = 360 + paddingTopAndBottom;
+  }
 
   if (columns === 1) {
     return Math.round(totalHeight / columns);

--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -31,7 +31,7 @@
           </p>
 
           <div class="hero-banner-actions">
-            <a class="button" href="https://mapc.az1.qualtrics.com/jfe/form/SV_832YVvNk2Yabzox">Goals</a>
+            <a class="button" href="https://mapc.az1.qualtrics.com/jfe/form/SV_b2t2u5mm1CkeFV3">Goals</a>
             <a class="button button--hollow button--with-arrow" href="https://youtu.be/bApghSqlbYc" target="_blank">Watch Video</a>
           </div>
         </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -2790,6 +2790,11 @@
         }
       }
     },
+    "eslint-plugin-jquery": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jquery/-/eslint-plugin-jquery-1.5.0.tgz",
+      "integrity": "sha512-+T+8qTML0/HVgdi/C8PFLQhNXyt+/6xz4AqD1g8ucPdma/OLLsJG7/HlnOJhR853nOu2cvwKUefASCl0EkLTXg=="
+    },
     "eslint-plugin-jsx-a11y": {
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "@rails/webpacker": "3.5",
     "activestorage": "^5.2.2",
     "audio-recorder-polyfill": "^0.1.3",
+    "eslint-plugin-jquery": "^1.5.0",
     "rails-erb-loader": "^5.5.2"
   },
   "devDependencies": {

--- a/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/_media.html.erb
@@ -21,7 +21,7 @@
   <% elsif media&.response.present? %>
     <div id="story<%= media.id %>" class="story--response">
       <div class="story--response-text">
-        <q href="/stories/<%= media.id %>"><%= strip_tags(media.response) %><q/>
+        <q href="/stories/<%= media.id %>"><%= strip_tags(media.response) %></q>
       </div>
       <p class="story__response--submitter-name">- <%= media.submitter_name %></p>
     </div>


### PR DESCRIPTION
Resolves updating Qualtrics links., response-text initial load and 3 column height calculation .

# Why is this change necessary?
* The Qualtrics goals survey was updated, and its ID changed.
* The initial loading of response texts was out of order due to javascript reloading from localStorage too soon.
* The height calculation was not accounting for total height of existing objects as intended.

# How does it address the issue?
The Qualtrics goals survey link was updated in the home page and in the large weigh-in prompt. The link in the weigh-in header text was changed in a previous pull request. 
The response text is now loaded after javascript stores existing texts, but no longer depends on window resize for the initial "reloading". (Window resize still functions as before, triggering reload of   response texts as size increases beyond our breakpoints.)
The height calculation now adds 360px to the totalHeight, if the existing calculation is NOT an even division by 360.

# What side effects does it have?
None.