### PR TITLE
Reduce limit for line clamping.

### DIFF
--- a/app/javascript/packs/response-text.js
+++ b/app/javascript/packs/response-text.js
@@ -12,7 +12,7 @@ $(() => {
     reloadStoryTexts();
     if (document.documentElement.clientWidth > 670) {
       $('div.story--response-text').succinct({
-        size: 400,
+        size: 350,
         omission: '...',
         ignore: false,
       });


### PR DESCRIPTION
Resolves issue of  too much text in line clamped story response.

This change reduces the amount of text where line clamping takes place, from 400 down to 350.

None. 
This will allow more room for the story response submitter's name, as requested by the Designer.
