### PR TITLE
Fix Broken Stories Header

### DIFF
--- a/vendor/extensions/stories/app/views/refinery/stories/stories/show.html.erb
+++ b/vendor/extensions/stories/app/views/refinery/stories/stories/show.html.erb
@@ -1,4 +1,4 @@
-<div class="banner">
+<div class="v2-banner">
   <div class="container">
     <div class="content-column banner-content">
       <h1><%= @page.try(:title) %></h1>


### PR DESCRIPTION
The stories header disappeared because its styling was disconnected from its class in 431c2b07ce59175b026460b13bce3f800d9bdf57. This commit fixes this by updating the class used in the page template to the v2-header class that now owns the styling we used on the page.
