### PR TITLE
Resolves # 328-report-template

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -95,3 +95,5 @@ gem 'refinerycms-hero_images', path: 'vendor/extensions'
 gem 'refinerycms-one_boxes', path: 'vendor/extensions'
 
 gem 'refinerycms-weigh_in_prompts', path: 'vendor/extensions'
+
+gem 'refinerycms-reports', path: 'vendor/extensions'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,9 @@ PATH
     refinerycms-one_boxes (1.0)
       acts_as_indexed (~> 0.8.0)
       refinerycms-core (~> 4.0.2)
+    refinerycms-reports (1.0)
+      acts_as_indexed (~> 0.8.0)
+      refinerycms-core (~> 4.0.2)
     refinerycms-stories (1.0)
       acts_as_indexed (~> 0.8.0)
       refinerycms-core (~> 4.0.2)
@@ -678,6 +681,7 @@ DEPENDENCIES
   refinerycms-hero_images!
   refinerycms-i18n
   refinerycms-one_boxes!
+  refinerycms-reports!
   refinerycms-search!
   refinerycms-stories!
   refinerycms-weigh_in_prompts!

--- a/app/assets/stylesheets/refinery/_all.scss
+++ b/app/assets/stylesheets/refinery/_all.scss
@@ -3,3 +3,4 @@
 @import 'home';
 @import 'process_timeline';
 @import 'find_out';
+@import 'report';

--- a/app/assets/stylesheets/refinery/report.scss
+++ b/app/assets/stylesheets/refinery/report.scss
@@ -41,29 +41,17 @@
       }
 
       &-image {
-        @include media(large) {
-          width: 37rem;
-        }
-
-        @include media(medium) {
-          width: 27rem;
-        }
-
         @include media(small) {
-          width: 17rem;
-        }
-
-        @include media(xsmall) {
-          width: 7rem;
+          float: none;
         }
 
         display: block;
         float: right;
         grid-column-start: 3;
         height: auto;
-        margin-right: 0;
-        padding: 0 0 2rem 2rem;
-        width: 55%;
+        margin: 0;
+        padding: 0 0 1rem 1rem;
+        width: 40vw;
       }
     }
   }

--- a/app/assets/stylesheets/refinery/report.scss
+++ b/app/assets/stylesheets/refinery/report.scss
@@ -1,0 +1,70 @@
+.Report {
+  background-color: white;
+
+  .report {
+    .v2-banner {
+      padding-bottom: 2rem;
+    }
+
+    p {
+      margin: 0;
+    }
+
+    &__content {
+      display: grid;
+      grid-auto-flow: dense;
+      grid-template-columns: 6rem 1fr 6rem;
+
+      &-date {
+        color: $v3-color_gray-dark;
+        display: block;
+        font-family: $font_family-secondary-light;
+        grid-column-start: 2;
+        margin-bottom: 1rem;
+        margin-top: 5rem;
+      }
+
+      &-title {
+        color: $v3-color_green-medium;
+        font-size: $font_size-xlarge;
+        grid-column-start: 2;
+        margin-bottom: 1rem;
+      }
+
+      &-body {
+        color: $v3-color_gray-dark;
+        font-size: $font_size-small;
+        grid-column-end: 4;
+        grid-column-start: 2;
+        margin: 0 6rem 3rem 0;
+        padding: 0;
+      }
+
+      &-image {
+        @include media(large) {
+          width: 37rem;
+        }
+
+        @include media(medium) {
+          width: 27rem;
+        }
+
+        @include media(small) {
+          width: 17rem;
+        }
+
+        @include media(xsmall) {
+          width: 7rem;
+        }
+
+        display: block;
+        float: right;
+        grid-column-start: 3;
+        height: auto;
+        margin-right: 0;
+        padding: 0 0 2rem 2rem;
+        width: 55%;
+      }
+    }
+  }
+}

--- a/app/views/refinery/_report_page.html.erb
+++ b/app/views/refinery/_report_page.html.erb
@@ -1,0 +1,6 @@
+<%= render_content_page(@page, {
+      :hide_sections => [local_assigns[:hide_sections], :body_content_title],
+      :can_use_fallback => !local_assigns[:show_empty_sections] && !local_assigns[:remove_automatic_sections]
+    }) %>
+<%= render '/refinery/draft_page_message' if @page && @page.draft? -%>
+<%= render '/refinery/skip_to_first_child_page_message' if @page && @page.skip_to_first_child? -%>

--- a/app/views/refinery/pages/report.html.erb
+++ b/app/views/refinery/pages/report.html.erb
@@ -1,0 +1,12 @@
+<div class="ReportTemplate">
+  <div class="report">
+    <div class="v2-banner"></div><!-- top green bar -->   
+      <div class="report__content">
+        <div class="report__content-date"><%= Time.now.strftime('%b %d, %Y') %></div>
+        <div class="report__content-title"><%= @page.title %></div>
+        <div class="report__content-body">
+          <%= render '/refinery/report_page' %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/db/migrate/20190618145500_create_reports_reports.refinery_reports.rb
+++ b/db/migrate/20190618145500_create_reports_reports.refinery_reports.rb
@@ -1,0 +1,31 @@
+# This migration comes from refinery_reports (originally 1)
+class CreateReportsReports < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :refinery_reports do |t|
+      t.string :title
+      t.text :body
+      t.datetime :date
+      t.integer :image_id
+      t.integer :position
+
+      t.timestamps
+    end
+
+
+  end
+
+
+  def down
+    if defined?(::Refinery::UserPlugin)
+      ::Refinery::UserPlugin.destroy_all({:name => "refinerycms-reports"})
+    end
+
+    if defined?(::Refinery::Page)
+      ::Refinery::Page.delete_all({:link_url => "/reports/reports"})
+    end
+
+    drop_table :refinery_reports
+
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -299,6 +299,23 @@ ActiveRecord::Schema.define(version: 2019_06_18_145500) do
     t.index ["refinery_story_id", "locale"], name: "index_845caebe798a0afcd0ff8f6d31a500cb83b87df7", unique: true
   end
 
+  create_table "refinery_taggings", force: :cascade do |t|
+    t.integer "tag_id"
+    t.integer "event_id"
+    t.integer "announcement_id"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "refinery_tags", force: :cascade do |t|
+    t.string "title"
+    t.string "tag_type"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "refinery_weigh_in_prompts", force: :cascade do |t|
     t.string "title"
     t.integer "image_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_01_202628) do
+ActiveRecord::Schema.define(version: 2019_06_18_145500) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -247,6 +247,16 @@ ActiveRecord::Schema.define(version: 2019_05_01_202628) do
     t.index ["lft"], name: "index_refinery_pages_on_lft"
     t.index ["parent_id"], name: "index_refinery_pages_on_parent_id"
     t.index ["rgt"], name: "index_refinery_pages_on_rgt"
+  end
+
+  create_table "refinery_reports", force: :cascade do |t|
+    t.string "title"
+    t.text "body"
+    t.datetime "date"
+    t.integer "image_id"
+    t.integer "position"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "refinery_resource_translations", id: :serial, force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -33,3 +33,6 @@ Refinery::OneBoxes::Engine.load_seed
 
 # Added by Refinery CMS WeighInPrompts extension
 Refinery::WeighInPrompts::Engine.load_seed
+
+# Added by Refinery CMS Reports extension
+Refinery::Reports::Engine.load_seed

--- a/spec/system/weigh_in_stories_spec.rb
+++ b/spec/system/weigh_in_stories_spec.rb
@@ -7,6 +7,7 @@ RSpec.describe 'Weigh In Stories', :type => :system do
     create(:weigh_in_prompt, style: 'small')
     visit '/stories'
     Capybara.current_session.driver.browser.manage.window.resize_to(1281, 1000)
-    expect(page).to have_xpath('//section[@id="stories"][@style="height: 784px;"]')
+
+    expect(page).to have_xpath('//section[@id="stories"][@style="height: 837px;"]')
   end
 end

--- a/spec/system/weigh_in_stories_spec.rb
+++ b/spec/system/weigh_in_stories_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe 'Weigh In Stories', :type => :system do
     visit '/stories'
     Capybara.current_session.driver.browser.manage.window.resize_to(1281, 1000)
 
-    expect(page).to have_xpath('//section[@id="stories"][@style="height: 837px;"]')
+    expect(page).to have_xpath('//section[@id="stories"][@style="height: 784px;"]')
   end
 end

--- a/vendor/extensions/reports/Gemfile
+++ b/vendor/extensions/reports/Gemfile
@@ -1,0 +1,43 @@
+source "https://rubygems.org"
+
+gemspec
+
+git 'https://github.com/refinery/refinerycms.git', :branch => 'master' do
+  gem 'refinerycms'
+
+  group :development, :test do
+    gem 'refinerycms-testing'
+  end
+end
+
+# Database Configuration
+platforms :jruby do
+  gem 'activerecord-jdbcsqlite3-adapter'
+  gem 'activerecord-jdbcmysql-adapter'
+  gem 'activerecord-jdbcpostgresql-adapter'
+  gem 'jruby-openssl'
+end
+
+platforms :ruby do
+  gem 'sqlite3'
+  gem 'mysql2', '~> 0.4.10'
+  gem 'pg'
+end
+
+group :development, :test do
+  gem 'rspec-its' # for the model's validation tests.
+  platforms :ruby do
+    require 'rbconfig'
+    if RbConfig::CONFIG['target_os'] =~ /linux/i
+      gem 'therubyracer', '~> 0.11.4'
+    end
+  end
+end
+
+# Gems used only for assets and not required
+# in production environments by default.
+group :assets do
+  gem 'sass-rails'
+  gem 'coffee-rails'
+  gem 'uglifier'
+end

--- a/vendor/extensions/reports/Rakefile
+++ b/vendor/extensions/reports/Rakefile
@@ -1,0 +1,19 @@
+#!/usr/bin/env rake
+begin
+  require 'bundler/setup'
+rescue LoadError
+  puts 'You must `gem install bundler` and `bundle install` to run rake tasks'
+end
+
+ENGINE_PATH = File.dirname(__FILE__)
+APP_RAKEFILE = File.expand_path "../spec/dummy/Rakefile", __FILE__
+
+if File.exists? APP_RAKEFILE
+  load 'rails/tasks/engine.rake'
+end
+
+require "refinerycms-testing"
+Refinery::Testing::Railtie.load_dummy_tasks ENGINE_PATH
+
+load File.expand_path('../tasks/testing.rake', __FILE__)
+load File.expand_path('../tasks/rspec.rake', __FILE__)

--- a/vendor/extensions/reports/app/controllers/refinery/reports/admin/reports_controller.rb
+++ b/vendor/extensions/reports/app/controllers/refinery/reports/admin/reports_controller.rb
@@ -1,0 +1,17 @@
+module Refinery
+  module Reports
+    module Admin
+      class ReportsController < ::Refinery::AdminController
+
+        crudify :'refinery/reports/report'
+
+        private
+
+        # Only allow a trusted parameter "permit list" through.
+        def report_params
+          params.require(:report).permit(:title, :body, :date, :image_id)
+        end
+      end
+    end
+  end
+end

--- a/vendor/extensions/reports/app/controllers/refinery/reports/reports_controller.rb
+++ b/vendor/extensions/reports/app/controllers/refinery/reports/reports_controller.rb
@@ -1,0 +1,34 @@
+module Refinery
+  module Reports
+    class ReportsController < ::ApplicationController
+
+      before_action :find_all_reports
+      before_action :find_page
+
+      def index
+        # you can use meta fields from your model instead (e.g. browser_title)
+        # by swapping @page for @report in the line below:
+        present(@page)
+      end
+
+      def show
+        @report = Report.find(params[:id])
+
+        # you can use meta fields from your model instead (e.g. browser_title)
+        # by swapping @page for @report in the line below:
+        present(@page)
+      end
+
+    protected
+
+      def find_all_reports
+        @reports = Report.order('position ASC')
+      end
+
+      def find_page
+        @page = ::Refinery::Page.where(link_url: "/reports").first
+      end
+
+    end
+  end
+end

--- a/vendor/extensions/reports/app/models/refinery/reports/report.rb
+++ b/vendor/extensions/reports/app/models/refinery/reports/report.rb
@@ -1,0 +1,17 @@
+module Refinery
+  module Reports
+    class Report < Refinery::Core::BaseModel
+      self.table_name = 'refinery_reports'
+
+
+      validates :title, :presence => true, :uniqueness => true
+
+      belongs_to :image, :class_name => '::Refinery::Image'
+
+      # To enable admin searching, add acts_as_indexed on searchable fields, for example:
+      #
+      #   acts_as_indexed :fields => [:title]
+
+    end
+  end
+end

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_actions.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_actions.html.erb
@@ -1,0 +1,20 @@
+<ul>
+  <% if ::Refinery::Reports::Admin::ReportsController.searchable? %>
+    <li>
+      <%= render '/refinery/admin/search', :url => refinery.reports_admin_reports_path %>
+    </li>
+  <% end %>
+  <li>
+    <%= action_label :add, refinery.new_reports_admin_report_path, t('.create_new') %>
+  </li>
+<% if !searching? && ::Refinery::Reports::Admin::ReportsController.sortable? && ::Refinery::Reports::Report.many? %>
+  <li>
+    <%= action_label :reorder,
+                     refinery.reports_admin_reports_path,
+                     t('.reorder', what:  "Reports"), id: 'reorder_action'%>
+    <%= action_label :reorder_done,
+                     refinery.reports_admin_reports_path,
+                      t('.reorder_done', what: "Reports"), id: 'reorder_action_done', class: 'hidden'%>
+  </li>
+<% end %>
+</ul>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
@@ -1,0 +1,45 @@
+<%= form_for [refinery, :reports_admin, @report] do |f| -%>
+  <%= render '/refinery/admin/error_messages',
+              :object => @report,
+              :include_object_name => true %>
+
+  <div class='field'>
+    <%= f.label :title -%>
+    <%= f.text_field :title, :class => 'larger widest' -%>
+  </div>
+
+  <div class='field'>
+    <%= render '/refinery/admin/wysiwyg',
+                :f => f,
+                :fields => [:body],
+                :object => "reports/report" -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :date -%>
+    <%= f.datetime_select :date -%>
+  </div>
+
+  <div class='field'>
+    <%= f.label :image -%>
+    <%= render '/refinery/admin/image_picker',
+               :f => f,
+               :field => :image_id,
+               :image => @report.image,
+               :toggle_image_display => false -%>
+  </div>
+
+  <%= render '/refinery/admin/form_actions', f: f,
+             continue_editing: false,
+             delete_title: t('delete', scope: 'refinery.reports.admin.reports.report'),
+             delete_confirmation: t('message', scope: 'refinery.admin.delete', title: @report.title),
+             cancel_url: refinery.reports_admin_reports_path -%>
+<% end -%>
+
+<% content_for :javascripts do -%>
+  <script>
+    $(document).ready(function(){
+      page_options.init(false, '', '');
+    });
+  </script>
+<% end -%>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_records.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_records.html.erb
@@ -1,0 +1,16 @@
+<%= render 'refinery/admin/search_header', :url => refinery.reports_admin_reports_path %>
+<div class='pagination_container'>
+  <% if @reports.any? %>
+    <%= render 'reports' %>
+  <% else %>
+    <p>
+      <% if searching? %>
+        <%= t('no_results', :scope => 'refinery.admin.search') %>
+      <% else %>
+        <strong>
+          <%= t('.no_items_yet') %>
+        </strong>
+      <% end %>
+    </p>
+  <% end %>
+</div>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_report.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_report.html.erb
@@ -1,0 +1,15 @@
+<li class='clearfix record <%= cycle("on", "on-hover") %>' id="<%= dom_id(report) -%>">
+  <span class='title'>
+    <%= report.title %>
+  </span>
+
+  <span class='preview'></span>
+
+  <span class='actions'>
+    <%= action_icon(:preview, refinery.reports_report_path(report), t('.view_live_html')) %>
+    <%= action_icon(:edit,    refinery.edit_reports_admin_report_path(report), t('.edit') ) %>
+    <%= action_icon(:delete,  refinery.reports_admin_report_path(report), t('.delete'),
+      { class: "cancel confirm-delete",
+        data: {confirm: t('message',  scope: 'refinery.admin.delete', title: report.title)}}  ) %>
+  </span>
+</li>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_reports.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_reports.html.erb
@@ -1,0 +1,2 @@
+<%= will_paginate @reports if Refinery::Reports::Admin::ReportsController.pageable? %>
+<%= render 'sortable_list' %>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_sortable_list.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_sortable_list.html.erb
@@ -1,0 +1,5 @@
+<ul id='sortable_list'>
+  <%= render :partial => 'report', :collection => @reports %>
+</ul>
+<%= render '/refinery/admin/sortable_list',
+            :continue_reordering => (local_assigns.keys.include?(:continue_reordering)) ? continue_reordering : true %>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/edit.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/edit.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/index.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/index.html.erb
@@ -1,0 +1,7 @@
+<section id='records'>
+  <%= render 'records' %>
+</section>
+<aside id='actions'>
+  <%= render 'actions' %>
+</aside>
+<%= render '/refinery/admin/make_sortable', options: {tree: false} if !searching? and ::Refinery::Reports::Admin::ReportsController.sortable? and ::Refinery::Reports::Report.many? %>

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/new.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/new.html.erb
@@ -1,0 +1,1 @@
+<%= render 'form' %>

--- a/vendor/extensions/reports/app/views/refinery/reports/reports/index.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/reports/index.html.erb
@@ -1,0 +1,11 @@
+<% content_for :body do %>
+  <ul id="reports">
+    <% @reports.each do |report| %>
+      <li>
+        <%= link_to report.title, refinery.reports_report_path(report) %>
+      </li>
+    <% end %>
+  </ul>
+<% end %>
+
+<%= render '/refinery/content_page' %>

--- a/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
@@ -1,7 +1,7 @@
 <div class="Report">
   <div class="report">
     <div class="v2-banner"></div><!-- top green bar -->   
-      <div class="report__content">
+      <div class="report__content container">
         <div class="report__content-date"><%= @report.date.strftime("%B %d, %Y") %></div>
         <div class="report__content-title">
           <%= @report.title %>

--- a/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
@@ -1,0 +1,16 @@
+<div class="Report">
+  <div class="report">
+    <div class="v2-banner"></div><!-- top green bar -->   
+      <div class="report__content">
+        <div class="report__content-date"><%= @report.date.strftime("%B %d, %Y") %></div>
+        <div class="report__content-title">
+          <%= @report.title %>
+        </div>
+        <div class="report__content-body">
+          <%= image_fu @report.image, nil, class: "report__content-image" %>
+           <%= raw @report.body %>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/vendor/extensions/reports/config/locales/cs.yml
+++ b/vendor/extensions/reports/config/locales/cs.yml
@@ -1,0 +1,30 @@
+cs:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Přidat Report
+            reorder: Řadit Reports
+            reorder_done: Konec řazení Reports
+          records:
+            title: Reports
+            sorry_no_results: Litujeme, ale nebyly nalezny žádné výsledky.
+            no_items_yet: Zatím nebyly vytvořeny žádné Reports. Zvolte "Přidat Report" pro přidání prvního report.
+          report:
+            view_live_html: Zobrazit náhled report<br/><em>(otevře se v novém okně)</em>
+            edit: Upravit report
+            delete: Smazat report
+      reports:
+        show:
+          other: Další Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/en.yml
+++ b/vendor/extensions/reports/config/locales/en.yml
@@ -1,0 +1,30 @@
+en:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Add New Report
+            reorder: Reorder Reports
+            reorder_done: Done Reordering Reports
+          records:
+            title: Reports
+            sorry_no_results: Sorry! There are no results found.
+            no_items_yet: There are no Reports yet. Click "Add New Report" to add your first report.
+          report:
+            view_live_html: View this report live <br/><em>(opens in a new window)</em>
+            edit: Edit this report
+            delete: Remove this report forever
+      reports:
+        show:
+          other: Other Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/es.yml
+++ b/vendor/extensions/reports/config/locales/es.yml
@@ -1,0 +1,31 @@
+es:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+#        article: masculino/femenino
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Crear nuevo report
+            reorder: Reordenar reports
+            reorder_done: Reordenación de reports completada
+          records:
+            title: Reports
+            sorry_no_results: Lo siento, no hay resultados
+            no_items_yet: No hay reports todavía. Pulsa en "Crear nuevo Report" para crear tu primer report.
+          report:
+            view_live_html: Ver este report como abierto al público <br/><em>(abre en ventana nueva)</em>
+            edit: Editar este report
+            delete: Borrar este report para siempre
+      reports:
+        show:
+          other: Otros reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/fr.yml
+++ b/vendor/extensions/reports/config/locales/fr.yml
@@ -1,0 +1,30 @@
+fr:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Créer un(e) nouve(au/l/lle) Report
+            reorder: Réordonner les Reports
+            reorder_done: Fin de réordonnancement des Reports
+          records:
+            title: Reports
+            sorry_no_results: "Désolé ! Aucun résultat."
+            no_items_yet: 'Il n''y a actuellement aucun(e) Report. Cliquer sur "Créer un(e) nouve(au/l/lle) Report" pour créer votre premi(er/ère) report.'
+          report:
+            view_live_html: Voir ce(t/tte) report <br/><em>(Ouvre une nouvelle fenêtre)</em>
+            edit: Modifier ce(t/tte) report
+            delete: Supprimer définitivement ce(t/tte) report
+      reports:
+        show:
+          other: Autres Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/it.yml
+++ b/vendor/extensions/reports/config/locales/it.yml
@@ -1,0 +1,30 @@
+it:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Aggiungi Nuovo Report
+            reorder: Riordina Reports
+            reorder_done: Termina il Riordino di Reports
+          records:
+            title: Reports
+            sorry_no_results: "Spiacenti! Nessun risultato trovato"
+            no_items_yet: Non ci sono ancora Reports. Clicca "Aggiungi Nuovo Report" per aggiungere il tuo primo report.
+          report:
+            view_live_html: Guarda live questo report <br/><em>(apre una nuova finestra)</em>
+            edit: Modifica questo report
+            delete: Rimuovi per sempre questo report
+      reports:
+        show:
+          other: Altri Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/nb.yml
+++ b/vendor/extensions/reports/config/locales/nb.yml
@@ -1,0 +1,30 @@
+nb:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Lag en ny Report
+            reorder: Endre rekkefølgen på Reports
+            reorder_done: Ferdig å endre rekkefølgen Reports
+          records:
+            title: Reports
+            sorry_no_results: Beklager! Vi fant ikke noen resultater.
+            no_items_yet: Det er ingen Reports enda. Klikk på "Lag en ny Report" for å legge til din første report.
+          report:
+            view_live_html: Vis hvordan denne report ser ut offentlig <br/><em>(åpner i et nytt vindu)</em>
+            edit: Rediger denne report
+            delete: Fjern denne report permanent
+      reports:
+        show:
+          other: Andre Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/nl.yml
+++ b/vendor/extensions/reports/config/locales/nl.yml
@@ -1,0 +1,30 @@
+nl:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Nieuwe Report toevoegen
+            reorder: De volgorde van de Reports wijzigen
+            reorder_done: Klaar met het wijzingen van de van de Report-volgorde
+          records:
+            title: Reports
+            sorry_no_results: Helaas! Er zijn geen resultaten gevonden.
+            no_items_yet: Er zijn nog geen Reports. Druk op 'Nieuwe Report toevoegen' om de eerste toe te voegen.
+          report:
+            view_live_html: Deze report op de website bekijken <br/><em>(opent in een nieuw venster)</em>
+            edit: Bewerk deze report
+            delete: Deze report definitief verwijderen
+      reports:
+        show:
+          other: Andere Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/ru.yml
+++ b/vendor/extensions/reports/config/locales/ru.yml
@@ -1,0 +1,30 @@
+ru:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Добавить Report
+            reorder: Изменить порядок Reports
+            reorder_done: Закончить изменять порядок Reports
+          records:
+            title: Reports
+            sorry_no_results: "Извините, поиск не дал результатов."
+            no_items_yet: Записей "Reports" не найдено. Нажмите "Добавить Report" чтобы создать report.
+          report:
+            view_live_html: Просмотреть report вживую <br/><em>(в новом окне)</em>
+            edit: Редактировать report
+            delete: Удалить report навсегда
+      reports:
+        show:
+          other: Другие Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/sk.yml
+++ b/vendor/extensions/reports/config/locales/sk.yml
@@ -1,0 +1,30 @@
+sk:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Pridať Report
+            reorder: Preusporiadať Reports
+            reorder_done: Koniec radenia Reports
+          records:
+            title: Reports
+            sorry_no_results: Ľutujeme, ale neboli nájdené žiadne výsledky.
+            no_items_yet: Nie sú vytvorené žiadne Reports. Kliknite na "Pridať Report" pre pridanie prvého report.
+          report:
+            view_live_html: Zobraziť náhľad report<br/><em>(otvorí sa v novom okne)</em>
+            edit: Upraviť report
+            delete: Zmazať report
+      reports:
+        show:
+          other: Daľšie Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/tr.yml
+++ b/vendor/extensions/reports/config/locales/tr.yml
@@ -1,0 +1,30 @@
+tr:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: Yeni Ekle Report
+            reorder: Tekrar sirala Reports
+            reorder_done: Tekrar siralama tamamlandiReports
+          records:
+            title: Reports
+            sorry_no_results: Uzgunum! Herhangi bir sonuc bulunamadi.
+            no_items_yet: Herhangi bir Reports yok henuz.  Tikla "Yeni Ekle Report" eklemek senin ilk report.
+          report:
+            view_live_html: Bunu canlu report goruntule <br/><em>(yeni bir pencerede acar)</em>
+            edit: Bunu Duzenle report
+            delete: Bunu Sil report sonsuza dek
+      reports:
+        show:
+          other: Diger Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/locales/zh-CN.yml
+++ b/vendor/extensions/reports/config/locales/zh-CN.yml
@@ -1,0 +1,32 @@
+zh-CN:
+  refinery:
+    plugins:
+      reports:
+        title: Reports
+    reports:
+      admin:
+        reports:
+          actions:
+            create_new: 建立新的 Report
+            reorder: 对 Reports 重新排序
+            reorder_done: 对 Reports 的重新排序结束
+          records:
+            title: Reports
+            sorry_no_results: 对不起，未找到结果。 #Sorry! There are no results found.
+
+            # There are no Reports yet. Click "Add New Report" to add your first report.
+            no_items_yet: 目前没有 Reports . 点击 "Add New Report" 创建一个report.
+          report:
+            view_live_html: 查看 report 的最新内容.<br/><em>(新窗口中打开)</em>
+            edit: 编辑 report
+            delete: 永久删除 report
+      reports:
+        show:
+          other: 其他 Reports
+  activerecord:
+    attributes:
+      'refinery/reports/report':
+        title: Title
+        body: Body
+        date: Date
+        image: Image

--- a/vendor/extensions/reports/config/routes.rb
+++ b/vendor/extensions/reports/config/routes.rb
@@ -1,0 +1,19 @@
+Refinery::Core::Engine.routes.draw do
+
+  # Frontend routes
+  namespace :reports do
+    resources :reports, :path => '', :only => [:index, :show]
+  end
+
+  # Admin routes
+  namespace :reports, :path => '' do
+    namespace :admin, :path => Refinery::Core.backend_route do
+      resources :reports, :except => :show do
+        collection do
+          post :update_positions
+        end
+      end
+    end
+  end
+
+end

--- a/vendor/extensions/reports/db/migrate/1_create_reports_reports.rb
+++ b/vendor/extensions/reports/db/migrate/1_create_reports_reports.rb
@@ -1,0 +1,30 @@
+class CreateReportsReports < ActiveRecord::Migration[5.2]
+
+  def up
+    create_table :refinery_reports do |t|
+      t.string :title
+      t.text :body
+      t.datetime :date
+      t.integer :image_id
+      t.integer :position
+
+      t.timestamps
+    end
+
+
+  end
+
+
+  def down
+    if defined?(::Refinery::UserPlugin)
+      ::Refinery::UserPlugin.destroy_all({:name => "refinerycms-reports"})
+    end
+
+    if defined?(::Refinery::Page)
+      ::Refinery::Page.delete_all({:link_url => "/reports/reports"})
+    end
+
+    drop_table :refinery_reports
+
+  end
+end

--- a/vendor/extensions/reports/db/seeds.rb
+++ b/vendor/extensions/reports/db/seeds.rb
@@ -1,0 +1,19 @@
+Refinery::I18n.frontend_locales.each do |lang|
+  I18n.locale = lang
+
+  Refinery::User.find_each do |user|
+    user.plugins.where(name: 'refinerycms-reports').first_or_create!(
+      position: (user.plugins.maximum(:position) || -1) +1
+    )
+  end if defined?(Refinery::User)
+
+  Refinery::Page.where(link_url: (url = "/reports")).first_or_create!(
+    title: 'Reports',
+    deletable: false,
+    menu_match: "^#{url}(\/|\/.+?|)$"
+  ) do |page|
+    Refinery::Pages.default_parts.each_with_index do |part, index|
+      page.parts.build title: part[:title], slug: part[:slug], body: nil, position: index
+    end
+  end if defined?(Refinery::Page)
+end

--- a/vendor/extensions/reports/lib/generators/refinery/reports_generator.rb
+++ b/vendor/extensions/reports/lib/generators/refinery/reports_generator.rb
@@ -1,0 +1,19 @@
+module Refinery
+  class ReportsGenerator < Rails::Generators::Base
+
+    def rake_db
+      rake "refinery_reports:install:migrations"
+    end
+
+    def append_load_seed_data
+      create_file 'db/seeds.rb' unless File.exists?(File.join(destination_root, 'db', 'seeds.rb'))
+      append_file 'db/seeds.rb', :verbose => true do
+        <<-EOH
+
+# Added by Refinery CMS Reports extension
+Refinery::Reports::Engine.load_seed
+        EOH
+      end
+    end
+  end
+end

--- a/vendor/extensions/reports/lib/refinery/reports.rb
+++ b/vendor/extensions/reports/lib/refinery/reports.rb
@@ -1,0 +1,21 @@
+require 'refinerycms-core'
+
+module Refinery
+  autoload :ReportsGenerator, 'generators/refinery/reports_generator'
+
+  module Reports
+    require 'refinery/reports/engine'
+
+    class << self
+      attr_writer :root
+
+      def root
+        @root ||= Pathname.new(File.expand_path('../../../', __FILE__))
+      end
+
+      def factory_paths
+        @factory_paths ||= [ root.join('spec', 'factories').to_s ]
+      end
+    end
+  end
+end

--- a/vendor/extensions/reports/lib/refinery/reports/engine.rb
+++ b/vendor/extensions/reports/lib/refinery/reports/engine.rb
@@ -1,0 +1,23 @@
+module Refinery
+  module Reports
+    class Engine < Rails::Engine
+      extend Refinery::Engine
+      isolate_namespace Refinery::Reports
+
+      engine_name :refinery_reports
+
+      before_inclusion do
+        Refinery::Plugin.register do |plugin|
+          plugin.name = "reports"
+          plugin.url = proc { Refinery::Core::Engine.routes.url_helpers.reports_admin_reports_path }
+          plugin.pathname = root
+          
+        end
+      end
+
+      config.after_initialize do
+        Refinery.register_extension(Refinery::Reports)
+      end
+    end
+  end
+end

--- a/vendor/extensions/reports/lib/refinerycms-reports.rb
+++ b/vendor/extensions/reports/lib/refinerycms-reports.rb
@@ -1,0 +1,1 @@
+require 'refinery/reports'

--- a/vendor/extensions/reports/lib/tasks/refinery/reports.rake
+++ b/vendor/extensions/reports/lib/tasks/refinery/reports.rake
@@ -1,0 +1,13 @@
+namespace :refinery do
+
+  namespace :reports do
+
+    # call this task by running: rake refinery:reports:my_task
+    # desc "Description of my task below"
+    # task :my_task => :environment do
+    #   # add your logic here
+    # end
+
+  end
+
+end

--- a/vendor/extensions/reports/readme.md
+++ b/vendor/extensions/reports/readme.md
@@ -1,0 +1,10 @@
+# Reports extension for Refinery CMS.
+
+## How to build this extension as a gem (not required)
+
+    cd vendor/extensions/reports
+    gem build refinerycms-reports.gemspec
+    gem install refinerycms-reports.gem
+
+    # Sign up for a https://rubygems.org/ account and publish the gem
+    gem push refinerycms-reports.gem

--- a/vendor/extensions/reports/refinerycms-reports.gemspec
+++ b/vendor/extensions/reports/refinerycms-reports.gemspec
@@ -1,0 +1,20 @@
+# Encoding: UTF-8
+
+Gem::Specification.new do |s|
+  s.platform          = Gem::Platform::RUBY
+  s.name              = 'refinerycms-reports'
+  s.version           = '1.0'
+  s.description       = 'Ruby on Rails Reports extension for Refinery CMS'
+  s.date              = '2019-06-18'
+  s.summary           = 'Reports extension for Refinery CMS'
+  s.authors           = 
+  s.require_paths     = %w(lib)
+  s.files             = Dir["{app,config,db,lib}/**/*"] + ["readme.md"]
+
+  # Runtime dependencies
+  s.add_dependency             'refinerycms-core',    '~> 4.0.2'
+  s.add_dependency             'acts_as_indexed',     '~> 0.8.0'
+
+  # Development dependencies (usually used for testing)
+  s.add_development_dependency 'refinerycms-testing', '~> 4.0.2'
+end

--- a/vendor/extensions/reports/script/rails
+++ b/vendor/extensions/reports/script/rails
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+# This command will automatically be run when you run "rails" with Rails 3 gems installed from the root of your application.
+
+ENGINE_PATH = File.expand_path('../..',  __FILE__)
+dummy_rails_path = File.expand_path('../../spec/dummy/script/rails',  __FILE__)
+if File.exist?(dummy_rails_path)
+  load dummy_rails_path
+else
+  puts "Please first run 'rake refinery:testing:dummy_app' to create a dummy Refinery CMS application."
+end

--- a/vendor/extensions/reports/spec/features/refinery/reports/admin/reports_spec.rb
+++ b/vendor/extensions/reports/spec/features/refinery/reports/admin/reports_spec.rb
@@ -1,0 +1,98 @@
+# encoding: utf-8
+require "spec_helper"
+
+describe Refinery do
+  describe "Reports" do
+    describe "Admin" do
+      describe "reports", type: :feature do
+        refinery_login
+
+        describe "reports list" do
+          before do
+            FactoryBot.create(:report, :title => "UniqueTitleOne")
+            FactoryBot.create(:report, :title => "UniqueTitleTwo")
+          end
+
+          it "shows two items" do
+            visit refinery.reports_admin_reports_path
+            expect(page).to have_content("UniqueTitleOne")
+            expect(page).to have_content("UniqueTitleTwo")
+          end
+        end
+
+        describe "create" do
+          before do
+            visit refinery.reports_admin_reports_path
+
+            click_link "Add New Report"
+          end
+
+          context "valid data" do
+            it "should succeed" do
+              fill_in "Title", :with => "This is a test of the first string field"
+              expect { click_button "Save" }.to change(Refinery::Reports::Report, :count).from(0).to(1)
+
+              expect(page).to have_content("'This is a test of the first string field' was successfully added.")
+            end
+          end
+
+          context "invalid data" do
+            it "should fail" do
+              expect { click_button "Save" }.not_to change(Refinery::Reports::Report, :count)
+
+              expect(page).to have_content("Title can't be blank")
+            end
+          end
+
+          context "duplicate" do
+            before { FactoryBot.create(:report, :title => "UniqueTitle") }
+
+            it "should fail" do
+              visit refinery.reports_admin_reports_path
+
+              click_link "Add New Report"
+
+              fill_in "Title", :with => "UniqueTitle"
+              expect { click_button "Save" }.not_to change(Refinery::Reports::Report, :count)
+
+              expect(page).to have_content("There were problems")
+            end
+          end
+
+        end
+
+        describe "edit" do
+          before { FactoryBot.create(:report, :title => "A title") }
+
+          it "should succeed" do
+            visit refinery.reports_admin_reports_path
+
+            within ".actions" do
+              click_link "Edit this report"
+            end
+
+            fill_in "Title", :with => "A different title"
+            click_button "Save"
+
+            expect(page).to have_content("'A different title' was successfully updated.")
+            expect(page).not_to have_content("A title")
+          end
+        end
+
+        describe "destroy" do
+          before { FactoryBot.create(:report, :title => "UniqueTitleOne") }
+
+          it "should succeed" do
+            visit refinery.reports_admin_reports_path
+
+            click_link "Remove this report forever"
+
+            expect(page).to have_content("'UniqueTitleOne' was successfully removed.")
+            expect(Refinery::Reports::Report.count).to eq(0)
+          end
+        end
+
+      end
+    end
+  end
+end

--- a/vendor/extensions/reports/spec/models/refinery/reports/report_spec.rb
+++ b/vendor/extensions/reports/spec/models/refinery/reports/report_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+module Refinery
+  module Reports
+    describe Report do
+      describe "validations", type: :model do
+        subject do
+          FactoryBot.create(:report,
+          :title => "Refinery CMS")
+        end
+
+        it { should be_valid }
+        its(:errors) { should be_empty }
+        its(:title) { should == "Refinery CMS" }
+      end
+    end
+  end
+end

--- a/vendor/extensions/reports/spec/spec_helper.rb
+++ b/vendor/extensions/reports/spec/spec_helper.rb
@@ -1,0 +1,30 @@
+# Configure Rails Environment
+ENV["RAILS_ENV"] ||= 'test'
+
+if File.exist?(dummy_path = File.expand_path('../dummy/config/environment.rb', __FILE__))
+  require dummy_path
+elsif File.dirname(__FILE__) =~ %r{vendor/extensions}
+  # Require the path to the refinerycms application this is vendored inside.
+  require File.expand_path('../../../../../config/environment', __FILE__)
+else
+  puts "Could not find a config/environment.rb file to require. Please specify this in #{File.expand_path(__FILE__)}"
+end
+
+require 'rspec/rails'
+require 'capybara/rspec'
+
+Rails.backtrace_cleaner.remove_silencers!
+
+RSpec.configure do |config|
+  config.mock_with :rspec
+  config.filter_run :focus => true
+  config.run_all_when_everything_filtered = true
+end
+
+# Requires supporting files with custom matchers and macros, etc,
+# in ./support/ and its subdirectories including factories.
+([Rails.root.to_s] | ::Refinery::Plugins.registered.pathnames).map{ |p|
+  Dir[File.join(p, 'spec', 'support', '**', '*.rb').to_s]
+}.flatten.sort.each do |support_file|
+  require support_file
+end

--- a/vendor/extensions/reports/spec/support/factories/refinery/reports.rb
+++ b/vendor/extensions/reports/spec/support/factories/refinery/reports.rb
@@ -1,0 +1,7 @@
+
+FactoryBot.define do
+  factory :report, :class => Refinery::Reports::Report do
+    sequence(:title) { |n| "refinery#{n}" }
+  end
+end
+

--- a/vendor/extensions/reports/tasks/rspec.rake
+++ b/vendor/extensions/reports/tasks/rspec.rake
@@ -1,0 +1,6 @@
+require 'rspec/core/rake_task'
+
+desc "Run specs"
+RSpec::Core::RakeTask.new do |t|
+  t.pattern = "./spec"
+end

--- a/vendor/extensions/reports/tasks/testing.rake
+++ b/vendor/extensions/reports/tasks/testing.rake
@@ -1,0 +1,8 @@
+namespace :refinery do
+  namespace :testing do
+    # Put any code in here that you want run when you test this extension against a dummy app.
+    # For example, the call to require your gem and start your generator.
+    task :setup_extension do
+    end
+  end
+end


### PR DESCRIPTION
Resolves # 328-report-template
* Add Report extension
* Style report extension show page, according to XD document, (without the 3 bottom boxes originally planned, for now).

# Why is this change necessary?
This provides a means to publish content in a report format, with date, title, body text and associated image.

# How does it address the issue?
This code creates a Refinery extension for Report, which will serve as a template for uploading content, as well as being "taggable" with the upcoming tags feature.

# What side effects does it have?
It has no bad side effects, although as an extension it is a different animal than the originally conceived report template within the "Pages" extension. However, it accomplishes the same user functionality with the added benefit of tag-ability (coming soon).


