### PR TITLE
Resolves #340 Report Extension Tags Functionality

### DIFF
--- a/db/migrate/20190617171718_create_taggings_taggings.refinery_taggings.rb
+++ b/db/migrate/20190617171718_create_taggings_taggings.refinery_taggings.rb
@@ -6,7 +6,6 @@ class CreateTaggingsTaggings < ActiveRecord::Migration[5.2]
       t.integer :tag_id
       t.integer :event_id
       t.integer :announcement_id
-      t.integer :report_id
       t.integer :position
 
       t.timestamps

--- a/db/migrate/20190617171718_create_taggings_taggings.refinery_taggings.rb
+++ b/db/migrate/20190617171718_create_taggings_taggings.refinery_taggings.rb
@@ -6,6 +6,7 @@ class CreateTaggingsTaggings < ActiveRecord::Migration[5.2]
       t.integer :tag_id
       t.integer :event_id
       t.integer :announcement_id
+      t.integer :report_id
       t.integer :position
 
       t.timestamps

--- a/db/migrate/20190709144342_add_report_id_to_taggings.rb
+++ b/db/migrate/20190709144342_add_report_id_to_taggings.rb
@@ -1,0 +1,5 @@
+class AddReportIdToTaggings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :refinery_taggings, :report_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_06_18_145500) do
+ActiveRecord::Schema.define(version: 2019_07_09_144342) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -303,10 +303,10 @@ ActiveRecord::Schema.define(version: 2019_06_18_145500) do
     t.integer "tag_id"
     t.integer "event_id"
     t.integer "announcement_id"
-    t.integer "report_id"
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "report_id"
   end
 
   create_table "refinery_tags", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -303,6 +303,7 @@ ActiveRecord::Schema.define(version: 2019_06_18_145500) do
     t.integer "tag_id"
     t.integer "event_id"
     t.integer "announcement_id"
+    t.integer "report_id"
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -17,9 +17,12 @@ RSpec.describe Refinery::Tags::Tag, :type => :model do
     new_tag = FactoryBot.create(:tag, title: 'Waste Management Video', tag_type: "content_type")
     new_event = FactoryBot.create(:event, title: "What I did last summer")
     new_announcement = FactoryBot.create(:announcement, title: "What I ate last night")
-    new_tagging1 = Refinery::Taggings::Tagging.create(tag_id: new_tag.id, event_id: new_event.id)
-    new_tagging2 = Refinery::Taggings::Tagging.create(tag_id: new_tag.id, announcement_id: new_announcement.id)
-    
-    expect(new_tag.taggings.count).to eq(2)
+    new_report = Refinery::Reports::Report.create(title: "When the dogs come back.", image: FactoryBot.create(:image))
+ 
+    Refinery::Taggings::Tagging.create(tag_id: new_tag.id, event_id: new_event.id)
+    Refinery::Taggings::Tagging.create(tag_id: new_tag.id, announcement_id: new_announcement.id)
+    Refinery::Taggings::Tagging.create(tag_id: new_tag.id, report_id: new_report.id)
+  
+    expect(new_tag.taggings.count).to eq(3)
   end
 end

--- a/spec/models/tagging_spec.rb
+++ b/spec/models/tagging_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe Refinery::Taggings::Tagging, :type => :model do
   it "it MUST have an associated model instance" do
     new_tag = FactoryBot.create(:tag, title: 'animals', tag_type: "topic_area")
     new_tagging = Refinery::Taggings::Tagging.create(tag_id: new_tag.id)
-    expect(new_tagging.errors.messages.count).to eq(1)
+ 
+    expect(new_tagging.errors.messages[:tagged_item_title][0]).to eq("can't be blank")
   end
 end

--- a/vendor/extensions/reports/app/controllers/refinery/reports/admin/reports_controller.rb
+++ b/vendor/extensions/reports/app/controllers/refinery/reports/admin/reports_controller.rb
@@ -5,12 +5,32 @@ module Refinery
 
         crudify :'refinery/reports/report'
 
+        def create
+          @report = Refinery::Reports::Report.create(report_params)
+          if params[:tag]
+            tags = params[:tag][:tag_ids].each do |tid|
+              Refinery::Taggings::Tagging.create(report_id: @report.id, tag_id: tid.to_i)
+            end
+          end
+          @report.save
+          redirect_to reports_admin_reports_path and return
+        end
+
+        def update
+          @report = Refinery::Reports::Report.find(params[:id])
+          @report.taggings.each {|t| t.delete}
+          tags = params[:tag][:tag_ids].each do |tid|
+            new_tagging = Refinery::Taggings::Tagging.create(report_id: @report.id, tag_id: tid.to_i)
+          end
+          redirect_to taggings_admin_taggings_path and return
+        end
+
         private
 
         # Only allow a trusted parameter "permit list" through.
         def report_params
-          params.require(:report).permit(:title, :body, :date, :image_id)
-        end
+          params.require(:report).permit(:title, :body, :date, :image_id, :link, :tag)
+         end
       end
     end
   end

--- a/vendor/extensions/reports/app/models/refinery/reports/report.rb
+++ b/vendor/extensions/reports/app/models/refinery/reports/report.rb
@@ -3,15 +3,29 @@ module Refinery
     class Report < Refinery::Core::BaseModel
       self.table_name = 'refinery_reports'
 
-
       validates :title, :presence => true, :uniqueness => true
-
       belongs_to :image, :class_name => '::Refinery::Image'
+      has_many :taggings, :class_name => '::Refinery::Taggings::Tagging'
+      has_many :tags, :class_name => '::Refinery::Tags::Tag', through: :taggings
 
-      # To enable admin searching, add acts_as_indexed on searchable fields, for example:
-      #
-      #   acts_as_indexed :fields => [:title]
+      def self.tagged_with(title)
+        Refinery::Tags::Tag.find_by_title!(title).reports
+      end
+      
+      def self.tag_counts
+        Refinery::Tags::Tag.select("tags.*, count(taggings.tag_id) as count").
+          joins(:taggings).group("taggings.tag_id")
+      end
+        
+      def tag_list
+        tags.map(&:title).join(", ")
+      end
 
+      def tag_list=(titles)
+        self.tags = titles.split(",").map do |t|
+          Refinery::Tags::Tag.where(title: t.strip).first_or_create!
+        end
+      end
     end
   end
 end

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
@@ -29,6 +29,26 @@
                :toggle_image_display => false -%>
   </div>
 
+  <%= f.label :tags -%>
+  <div class="tags">
+    <div class='tags__header'>Choose Content_Type(s)</div>
+    <div>
+      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
+         <span class="tags__selector"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"
+        <%= 'checked' if @report.tags.include?(tag) %>><%= tag.title %></input></span>
+      <% end %>
+    </div>
+    <br />
+
+    <div class='tags__header'>Choose Topic_Area(s)</div>
+    <div>
+      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
+        <span class="tags__selector"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"
+        <%= 'checked' if @report.tags.include?(tag) %> class="tags__selector-selected"><%= tag.title %></input></span>
+      <% end %>
+    </div>
+  </div>
+
   <%= render '/refinery/admin/form_actions', f: f,
              continue_editing: false,
              delete_title: t('delete', scope: 'refinery.reports.admin.reports.report'),

--- a/vendor/extensions/taggings/app/models/refinery/taggings/tagging.rb
+++ b/vendor/extensions/taggings/app/models/refinery/taggings/tagging.rb
@@ -7,6 +7,7 @@ module Refinery
       belongs_to :tag, :class_name => '::Refinery::Tags::Tag'
       belongs_to :event, :class_name => '::Refinery::Events::Event', optional: true
       belongs_to :announcement, :class_name => '::Refinery::Announcements::Announcement', optional: true
+      belongs_to :report, :class_name => '::Refinery::Reports::Report', optional: true
 
       def self.total_pages
         self.count / 12
@@ -29,6 +30,8 @@ module Refinery
           "event"
         elsif announcement
           "announcement"
+        elsif report
+          "report"
         else
         end
       end
@@ -42,6 +45,8 @@ module Refinery
           event.title.downcase.lstrip
         elsif announcement
           announcement.title.downcase.lstrip
+        elsif report
+          report.title.downcase.lstrip
         else
         end
       end

--- a/vendor/extensions/taggings/app/views/refinery/taggings/admin/taggings/index.html.erb
+++ b/vendor/extensions/taggings/app/views/refinery/taggings/admin/taggings/index.html.erb
@@ -32,6 +32,18 @@
             { class: "cancel confirm-delete",
             data: {confirm: t('message',  scope: 'refinery.admin.delete', title: t.tag_title)}}  ) %></span>
         </td>
+      <% elsif t.report %>
+        <td><%= t.report.title %></td>
+        <td><%= t.extension_class_name %></td>
+        <td><%= t.tag.title %></td>
+        <td><%= t.tag.tag_type %></td>
+        <td><span class='actions'>
+          <%= action_icon(:preview, "/reports/#{t.report_id}", t('.view_live_html')) %>
+          <%= action_icon(:edit, "/hubadmin/reports/#{t.report_id}/edit", t('.edit')) %>
+          <%= action_icon(:delete,  refinery.taggings_admin_tagging_path(t), t('.delete'),
+            { class: "cancel confirm-delete",
+            data: {confirm: t('message',  scope: 'refinery.admin.delete', title: t.tag_title)}}  ) %></span>
+        </td>
       <% end %>
     </tr>
   <% end %>

--- a/vendor/extensions/taggings/db/migrate/1_create_taggings_taggings.rb
+++ b/vendor/extensions/taggings/db/migrate/1_create_taggings_taggings.rb
@@ -5,6 +5,7 @@ class CreateTaggingsTaggings < ActiveRecord::Migration[5.2]
       t.integer :tag_id
       t.integer :event_id
       t.integer :announcement_id
+      t.integer :report_id
       t.integer :position
 
       t.timestamps

--- a/vendor/extensions/tags/app/models/refinery/tags/tag.rb
+++ b/vendor/extensions/tags/app/models/refinery/tags/tag.rb
@@ -9,6 +9,7 @@ module Refinery
       has_many :taggings, :class_name => '::Refinery::Taggings::Tagging', dependent: :destroy
       has_many :events, :class_name => '::Refinery::Events::Event', through: :taggings
       has_many :announcements, :class_name => '::Refinery::Announcements::Announcement', through: :taggings
+      has_many :reports, :class_name => '::Refinery::Reports::Report', through: :taggings
 
       enum tag_type: {
         content_type: "content_type",


### PR DESCRIPTION
# Why is this change necessary?
This code adds the functionality to tag Report extension instances.

# How does it address the issue?
It gives the Report extension the same "tag-ability" in the hubadmin console, as was done for Announcement and Event extensions

# What side effects does it have?
The only issue I found was that FactoryBot is currently not registering the Report model in testing.
As a work-around, I modified the tests to call the database model directly for producing test Reports.
