### PR TITLE
Add static, branded, goals gitbook page

### DIFF
--- a/app/assets/stylesheets/refinery/_all.scss
+++ b/app/assets/stylesheets/refinery/_all.scss
@@ -4,3 +4,4 @@
 @import 'process_timeline';
 @import 'find_out';
 @import 'report';
+@import 'goals';

--- a/app/assets/stylesheets/refinery/goals.scss
+++ b/app/assets/stylesheets/refinery/goals.scss
@@ -1,0 +1,11 @@
+.Goals {
+  height: 110rem;
+
+  .container:after {
+   z-index: 9;
+  }
+
+  iframe {
+    padding-top: .5rem;
+  }
+}

--- a/app/assets/stylesheets/refinery/goals.scss
+++ b/app/assets/stylesheets/refinery/goals.scss
@@ -2,7 +2,7 @@
   height: 110rem;
 
   .container:after {
-   z-index: 9;
+   display: none;
   }
 
   iframe {

--- a/app/views/refinery/_goals.html.erb
+++ b/app/views/refinery/_goals.html.erb
@@ -1,0 +1,1 @@
+<iframe src="https://metrocommon-2050.gitbook.io/metrocommon-2050-goals/" height="100%" width="100%" frameborder="0" allowfullscreen></iframe>

--- a/app/views/refinery/pages/goals.html.erb
+++ b/app/views/refinery/pages/goals.html.erb
@@ -1,0 +1,8 @@
+<div class="Goals">
+  <section class="v2-banner">
+    <div class="container"></div>
+  </section>
+    <iframe></iframe>
+    <%= render partial: 'refinery/goals' %>
+  <div class="container"></div>
+</div>

--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -30,7 +30,7 @@
           </p>
 
           <div class="hero-banner-actions">
-            <a class="button" href="https://metrocommon-2050.gitbook.io/metrocommon-2050-goals/" target="_blank">Goals</a>
+            <a class="button" href="/goals">Goals</a>
             <a class="button button--hollow button--with-arrow" href="https://youtu.be/bApghSqlbYc" target="_blank">Watch Video</a>
           </div>
         </div>


### PR DESCRIPTION
Resolves #334 static goals page.

# Why is this change necessary?
The requirement to have a dedicated page for viewing the Goals gitbook in a branded static page, instead of opening a separate tab (unbranded).

# How does it address the issue?
This creates a branded static goals page where external content can be displayed.

# What side effects does it have?
1.  Not a side-effect but a work around. After some experimenting, I had to "fake out" Refinerycms by putting the iframe into a Rails partial and putting an empty <iframe></iframe> set of tags in the parent goals.html.erb page.  I could not find any other combination that would render the page.

2.  The class "Goals" has a static height of 105rem, to overrule the .container class. This allows the full gitbook to display without scrolling up and down.

3.  The trademark aqua green triangle is still in the top header, but I like how it seems to point you to type into the gitbook search bar. (This was not in the mockup image, so I'm pointing it out in case it is not desired.)

![goals_page_green_arrow](https://user-images.githubusercontent.com/16054332/61290983-2d1aa080-a79b-11e9-917c-d41543011470.png)



