### PR TITLE
Add published_date to Announcement model

### DIFF
--- a/db/migrate/20190726174549_add_published_date_to_announcements.rb
+++ b/db/migrate/20190726174549_add_published_date_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddPublishedDateToAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :refinery_announcements, :published_date, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_19_172715) do
+ActiveRecord::Schema.define(version: 2019_07_26_174549) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -69,6 +69,7 @@ ActiveRecord::Schema.define(version: 2019_07_19_172715) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "published_date"
   end
 
   create_table "refinery_authentication_devise_roles", id: :serial, force: :cascade do |t|

--- a/spec/models/announcement_spec.rb
+++ b/spec/models/announcement_spec.rb
@@ -30,4 +30,13 @@ RSpec.describe Refinery::Announcements::Announcement, :type => :model do
 
     expect(announcement1.tags[1].tag_type).to eq('topic_area')
   end
+
+  it "it MUST have a published_date", js: true do
+    tag1 = Refinery::Tags::Tag.create(title: 'news', narrative: "We do announcements on a specific date.", tag_type: "content_type")
+    announcement1 = FactoryBot.create(:announcement, title: 'Test Announcement Title', published_date: '02-03-2018')
+    announcement1.tags.push(tag1)
+    announcement1.save
+
+    expect(announcement1.published_date.month).to eq(3)
+  end
 end

--- a/vendor/extensions/announcements/app/controllers/refinery/announcements/admin/announcements_controller.rb
+++ b/vendor/extensions/announcements/app/controllers/refinery/announcements/admin/announcements_controller.rb
@@ -33,7 +33,7 @@ module Refinery
 
         # Only allow a trusted parameter "white list" through.
         def announcement_params
-          params.require(:announcement).permit(:title, :body, :image_id, :link, :tag)
+          params.require(:announcement).permit(:title, :body, :published_date, :image_id, :link, :tag)
         end
       end
     end

--- a/vendor/extensions/announcements/app/serializers/announcement_serializer.rb
+++ b/vendor/extensions/announcements/app/serializers/announcement_serializer.rb
@@ -1,6 +1,6 @@
 class AnnouncementSerializer
   include FastJsonapi::ObjectSerializer
-  attributes :title, :body, :link, :position, :tags, :image
+  attributes :title, :body, :link, :position, :published_date, :tags, :image
   has_one :image, :class_name => '::Refinery::Image'
   has_many :taggings, :class_name => '::Refinery::Taggings::Tagging'
   has_many :tags, :class_name => '::Refinery::Tags::Tag', through: :taggings

--- a/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
@@ -12,7 +12,7 @@
 
   <div class='field'>
     <%= f.label :published_date -%>
-    <%= f.date_field :published_date, required: true -%>
+    <%= f.date_select :published_date, required: true -%>
   </div>
 
   <div class='field'>

--- a/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
@@ -11,6 +11,11 @@
   </div>
 
   <div class='field'>
+    <%= f.label :published_date -%>
+    <%= f.date_field :published_date, required: true -%>
+  </div>
+
+  <div class='field'>
     <%= render '/refinery/admin/wysiwyg',
                 :f => f,
                 :fields => [:body],


### PR DESCRIPTION
Resolves #351 

# Why is this change necessary?
A date field is needed for the Announcement model, for depicting when it was published and for use in sorting filtered taggings. 

# How does it address the issue?
It adds the column `published_date` to the announcements table
It adds `:published_date` to the announcement_serializer.rb
It adds `:published_date` to the strong params in announcement_controller.rb
It adds a test for the presence of a `published_date` to the announcement_spec.rb test file
It adds a date entry field in the hub admin for Announcements and is required before saving or updating.

# What side effects does it have?
None