### PR TITLE
Remove selected tables via migration

### DIFF
--- a/db/migrate/20190731153846_remove_selected_tables.rb
+++ b/db/migrate/20190731153846_remove_selected_tables.rb
@@ -1,0 +1,11 @@
+class RemoveSelectedTables < ActiveRecord::Migration[5.2]
+  def up
+    drop_table :refinery_tags
+    drop_table :refinery_taggings
+    drop_table :refinery_reports
+  end
+
+  def down
+    raise ActiveRecord::IrreversibleMigration
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_01_202628) do
+ActiveRecord::Schema.define(version: 2019_07_31_153846) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Resolves #372

## Why is this change necessary?
Due to the extraneous code currently in Master, which came from Develop before we actually intended it, there are database changes that are needed to revert back to the state of the database before the unwanted merge occurred. 

## How does it address the issue?
This code provides a rails migration to remove 3 tables that should not be on master at this time:
 `refinery_reports`
 `refinery_tags`
 `refinery_taggings`

## What side effects does it have?
None