### PR TITLE
Att/364 mobile style footer

### DIFF
--- a/app/assets/stylesheets/global/_vars.scss
+++ b/app/assets/stylesheets/global/_vars.scss
@@ -7,6 +7,7 @@ $font_size-xlarge: 2.1875rem; // 35px
 
 // font sizes in v3 home page
 $v3_font_size-h1: 2.6875rem;
+$v3_font_size-h1-mobile: 1.7rem;
 // sub heading - $font_size-large
 $v3_font_size-button: 1.125rem; // button text
 $v3_font_size-title: 1.8rem; // announcements title

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -1,11 +1,156 @@
 .footer {
-  display: flex;
-  flex-wrap: wrap;
   background-color: $color_bg-dark;
   font-size: $font_size-xsmall;
   color: $color_font-light;
   line-height: $font_size-small;
   transition-duration: 1.5s;
+
+  background: lightblue;
+
+  & > .container{
+    display: -ms-grid;
+    display: grid;
+
+    -ms-grid-columns: 1fr 1fr 1fr 1fr;
+    grid-template-columns: repeat(4,1fr);
+
+    -ms-grid-rows: auto;
+    grid-template-rows: auto;
+
+
+    & > *:nth-child(1){
+      -ms-grid-row: 1;
+      -ms-grid-column: 1;
+      border: 1px solid red;
+    }
+    & > *:nth-child(2){
+      -ms-grid-row: 1;
+      -ms-grid-column: 2;
+      border: 1px solid red;
+    }
+    & > *:nth-child(3){
+      -ms-grid-row: 1;
+      -ms-grid-column: 3;
+      border: 1px solid red;
+    }
+    & > *:nth-child(4){
+      -ms-grid-row: 1;
+      -ms-grid-column: 4;
+      border: 1px solid red;
+    }
+
+    & > *:nth-child(5){
+      -ms-grid-row: 2;
+      -ms-grid-column: 1;
+      border: 1px solid red;
+    }
+    & > *:nth-child(6){
+      -ms-grid-row: 2;
+      -ms-grid-column: 2;
+      border: 1px solid red;
+    }
+    & > *:nth-child(7){
+      -ms-grid-row: 2;
+      -ms-grid-column: 4;
+      border: 1px solid red;
+    }
+
+    justify-content: start;
+    padding-bottom: 1rem;
+    max-width: 100%;
+    padding: 3.4rem 6rem;
+
+    @include media(small){
+      grid-template-columns: 1fr 1fr;
+      //grid-auto-rows: repeat(9, fit-content(1fr));
+    }
+
+  }
+
+  // .footer-mapc-brand {
+  //   display: flex;
+  //   align-items: center;
+  //   .logo {
+  //     width: 72px;
+  //     height: 36px;
+  //     margin-right: 1em;
+  //   }
+
+  //   @include media(medium) {
+  //     display: block;
+  //     & > *:not(:last-child) {
+  //       margin-bottom: 0.5rem;
+  //     }
+  //   }
+  // }
+
+  &__section{
+    &-about{
+      @include media(small){
+        grid-column: 1 / span 2;
+        grid-row: 1 / span 3;
+      }
+    }
+
+    &-links{
+      @include media(small){
+        grid-row: 4 / span 3;
+        grid-column: 1;
+      }
+    }
+
+    &-explore{
+      @include media(small){
+        grid-row: 4 / span 3;
+        grid-column: 2;
+      }
+    }
+
+    &-contact{
+      @include media(small){
+        grid-row: 7/ span 3;
+        grid-column: 2;
+      }
+    }
+
+    &-images{
+      &-logo{
+        display: flex;
+        align-items: center;
+        width: 72px;
+        height: 36px;
+        margin-right: 1em;
+
+        @include media(small){
+          grid-row: 7;
+          grid-column: 1;
+        }
+
+        @include media(medium) {
+          display: block;
+          & > *:not(:last-child) {
+            margin-bottom: 0.5rem;
+          }
+        }
+      }
+
+      &-cta{
+        grid-column: 2;
+        @include media(small){
+          grid-row: 8;
+          grid-column: 1;
+        }
+      }
+
+      &-social{
+        grid-column: 4;
+        @include media(small){
+          grid-row: 9;
+          grid-column: 1;
+        }
+      }
+    }
+  }
 
   // Override normal green coloring
   a {
@@ -24,6 +169,11 @@
     li {
       margin-bottom: 0.2rem;
     }
+  }
+
+  .footer__section--image{
+    width: 72px;
+    height:36px;
   }
 
   .footer__row {
@@ -62,21 +212,6 @@
     }
   }
 
-  .footer-mapc-brand {
-    display: flex;
-    align-items: center;
-    .logo {
-      width: 72px;
-      height: 36px;
-      margin-right: 1em;
-    }
-
-    @include media(medium) {
-      display: block;
-      & > *:not(:last-child) {
-        margin-bottom: 0.5rem;
-      }
-    }
-  }
+  
 }
 }

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -33,7 +33,6 @@
      padding-bottom: 1rem;
      @include media(small) {
        display: block;
-     }
   }
 
   .footer__column {
@@ -79,4 +78,5 @@
       }
     }
   }
+}
 }

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -8,78 +8,45 @@
   & > .container{
     display: -ms-grid;
     display: grid;
-
     -ms-grid-columns: 1fr 1fr 1fr 1fr;
     grid-template-columns: repeat(4,1fr);
-
     -ms-grid-rows: auto;
     grid-template-rows: auto;
 
-
-    & > *:nth-child(1){
-      -ms-grid-row: 1;
-      -ms-grid-column: 1;
-      border: 1px solid red;
-    }
-    & > *:nth-child(2){
-      -ms-grid-row: 1;
-      -ms-grid-column: 2;
-      border: 1px solid red;
-    }
-    & > *:nth-child(3){
-      -ms-grid-row: 1;
-      -ms-grid-column: 3;
-      border: 1px solid red;
-    }
-    & > *:nth-child(4){
-      -ms-grid-row: 1;
-      -ms-grid-column: 4;
-      border: 1px solid red;
-    }
-
-    & > *:nth-child(5){
-      -ms-grid-row: 2;
-      -ms-grid-column: 1;
-      border: 1px solid red;
-    }
-    & > *:nth-child(6){
-      -ms-grid-row: 2;
-      -ms-grid-column: 2;
-      border: 1px solid red;
-    }
-    & > *:nth-child(7){
-      -ms-grid-row: 2;
-      -ms-grid-column: 4;
-      border: 1px solid red;
-    }
-
-    justify-content: start;
     padding-bottom: 1rem;
     max-width: 100%;
     padding: 3.4rem 6rem;
 
     @include media(medium){
       grid-template-columns: 1fr 1fr;
-      //grid-auto-rows: repeat(9, fit-content(1fr));
       padding: 1.55rem 1.25rem;
     }
   }
 
   &__section {
-    address {
-      margin-bottom: 1rem;
-    }
-
     &-about{
-      margin-right: 8.05rem;
+      -ms-grid-row: 1;
+      -ms-grid-column: 1;
+      grid-row: 1;
+      grid-column: 1;
+
+      padding-right: 8.05rem;
+
+      @media(max-width: 1460px){
+        padding-right: 2rem;
+      }
       @include media(medium){
         grid-column: 1 / span 2;
         grid-row: 1 / span 3;
-        margin-right: 0;
       }
     }
 
     &-links{
+      -ms-grid-row: 1;
+      -ms-grid-column: 2;
+      grid-row: 1;
+      grid-column: 2;
+
       @include media(medium){
         grid-row: 4 / span 3;
         grid-column: 1;
@@ -87,6 +54,11 @@
     }
 
     &-explore{
+      -ms-grid-row: 1;
+      -ms-grid-column: 3;
+      grid-row: 1;
+      grid-column: 3;
+
       @include media(medium){
         grid-row: 4 / span 3;
         grid-column: 2;
@@ -94,19 +66,32 @@
     }
 
     &-contact{
-      @include media(medium){
-        grid-row: 7/ span 3;
-        grid-column: 2;
+      -ms-grid-row: 1;
+      -ms-grid-column: 4;
+      grid-row: 1;
+      grid-column: 4;
+
+      address {
+        margin-bottom: 1rem;
       }
-      &-web{
-        @include media(medium){
-          display:none;
+
+      @include media(medium){
+        grid-row: 7 / span 3;
+        grid-column: 2;
+
+        &-web{
+          display: none;
         }
       }
     }
 
     &-images{
       &-logo{
+        -ms-grid-row: 2;
+        -ms-grid-column: 1;
+        grid-row: 2;
+        grid-column: 1;
+
         margin-right: 1em;
         width: 6.05rem;
         height: 3.35rem;
@@ -128,20 +113,31 @@
       }
 
       &-cta{
+        -ms-grid-row: 2;
+        -ms-grid-column: 2;
+        grid-row: 2;
         grid-column: 2;
+
         @include media(medium){
           grid-row: 8;
           grid-column: 1;
           margin-top: 0.5rem;
-        }
+        }        
 
         .button {
           text-transform: uppercase;
           font-family: "CalibreWeb-Semibold";
+
+          @include media(small){
+            min-width: 6.25rem;
+          }
         }
       }
 
       &-social{
+        -ms-grid-row: 2;
+        -ms-grid-column: 4;
+        grid-row: 2;
         grid-column: 4;
         font-size: $font_size-medium;
         a {

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -5,8 +5,6 @@
   line-height: $font_size-small;
   transition-duration: 1.5s;
 
-  background: lightblue;
-
   & > .container{
     display: -ms-grid;
     display: grid;
@@ -60,70 +58,65 @@
     max-width: 100%;
     padding: 3.4rem 6rem;
 
-    @include media(small){
+    @include media(medium){
       grid-template-columns: 1fr 1fr;
       //grid-auto-rows: repeat(9, fit-content(1fr));
+      padding: 1.55rem 1.25rem;
     }
-
   }
 
-  // .footer-mapc-brand {
-  //   display: flex;
-  //   align-items: center;
-  //   .logo {
-  //     width: 72px;
-  //     height: 36px;
-  //     margin-right: 1em;
-  //   }
+  &__section {
+    address {
+      margin-bottom: 1rem;
+    }
 
-  //   @include media(medium) {
-  //     display: block;
-  //     & > *:not(:last-child) {
-  //       margin-bottom: 0.5rem;
-  //     }
-  //   }
-  // }
-
-  &__section{
     &-about{
-      @include media(small){
+      margin-right: 8.05rem;
+      @include media(medium){
         grid-column: 1 / span 2;
         grid-row: 1 / span 3;
+        margin-right: 0;
       }
     }
 
     &-links{
-      @include media(small){
+      @include media(medium){
         grid-row: 4 / span 3;
         grid-column: 1;
       }
     }
 
     &-explore{
-      @include media(small){
+      @include media(medium){
         grid-row: 4 / span 3;
         grid-column: 2;
       }
     }
 
     &-contact{
-      @include media(small){
+      @include media(medium){
         grid-row: 7/ span 3;
         grid-column: 2;
+      }
+      &-web{
+        @include media(medium){
+          display:none;
+        }
       }
     }
 
     &-images{
       &-logo{
-        display: flex;
-        align-items: center;
-        width: 72px;
-        height: 36px;
         margin-right: 1em;
+        width: 6.05rem;
+        height: 3.35rem;
 
-        @include media(small){
+        @include media(medium){
           grid-row: 7;
           grid-column: 1;
+          margin-top: 0.5rem;
+          width: 3.6rem;
+          height: 1.8rem;
         }
 
         @include media(medium) {
@@ -136,23 +129,38 @@
 
       &-cta{
         grid-column: 2;
-        @include media(small){
+        @include media(medium){
           grid-row: 8;
           grid-column: 1;
+          margin-top: 0.5rem;
+        }
+
+        .button {
+          text-transform: uppercase;
+          font-family: "CalibreWeb-Semibold";
         }
       }
 
       &-social{
         grid-column: 4;
-        @include media(small){
+        font-size: $font_size-medium;
+        a {
+          padding: 0 1rem 0 0;
+        }
+        @include media(medium){
           grid-row: 9;
           grid-column: 1;
+          margin-top: 0.5rem;
         }
       }
     }
   }
 
   // Override normal green coloring
+  & h2 {
+    color: $color_font-light;
+  }
+
   a {
     color: $color_font-light;
     text-decoration: none;
@@ -175,43 +183,4 @@
     width: 72px;
     height:36px;
   }
-
-  .footer__row {
-     display: flex;
-     flex-basis: 100%;
-     justify-content: space-between;
-     padding-bottom: 1rem;
-     @include media(small) {
-       display: block;
-  }
-
-  .footer__column {
-    flex-basis: 22%;
-    .button {
-      text-transform: uppercase;
-      font-family: "CalibreWeb-Semibold";
-    }
-
-    h2 {
-      color: $color_font-light;
-    }
-
-    address {
-      margin-bottom: 1rem;
-    }
-
-    @include media(small) {
-      margin-bottom: 1rem;
-    }
-  }
-
-  .footer__column--social {
-    font-size: $font_size-medium;
-    a {
-      padding: 0 1rem 0 0;
-    }
-  }
-
-  
-}
 }

--- a/app/views/refinery/_footer.html.erb
+++ b/app/views/refinery/_footer.html.erb
@@ -32,13 +32,15 @@
         Boston MA 02111<br>
         <a href="tel:6179330700">617-933-0700</a>
       </address>
-      <a href="/">metrocommon.mapc.org</a>
+      <p class="footer__section-contact-web">
+        <a href="/">metrocommon.mapc.org</a
+      </p>
     </div>
 
 
    
-    <div class="footer_section-images-logo">
-      </div>
+    <div class="footer__section-images-logo">
+      <%= link_to 'https://www.mapc.org/', class: 'footer-mapc-brand' do %>
        <%= image_tag("mapc-logo.svg", class: "footer_section-images-logo", alt: t('logo_alt')) %>
      <% end %>
     </div>
@@ -47,17 +49,6 @@
       <a class="button" rel="noopener noreferrer" href="<%= CONSTANT_CONTACT_LANDING_PAGE %>" target="_blank">Receive Updates</a>
     </div>
     <div class="footer__section-images-social">
-      <div class="footer__column">
-        <%= link_to 'https://www.mapc.org/', class: 'footer-mapc-brand' do %>
-          <%= image_tag("mapc-logo.svg", class: "logo", alt: t('logo_alt')) %>
-        <% end %>
-      </div>
-      <div class="footer__column">
-        <a class="button" rel="noopener noreferrer" href="<%= CONSTANT_CONTACT_LANDING_PAGE %>" target="_blank">Receive Updates</a>
-      </div>
-      <div class="footer__column">
-      </div>
-      <div class="footer__column footer__column--social">
       <a aria-label="MAPC Twitter Page" href="https://twitter.com/mapcmetroboston"><%= fa_icon "twitter" %></a>
       <a aria-label="MAPC Instagram Page" href="https://www.instagram.com/mapcmetroboston"><%= fa_icon "instagram" %></a>
       <a aria-label="MAPC Facebook Page" href="https://www.facebook.com/mapcmetroboston"><%= fa_icon "facebook" %></a>

--- a/app/views/refinery/_footer.html.erb
+++ b/app/views/refinery/_footer.html.erb
@@ -1,12 +1,12 @@
 <footer class="footer">
   <div class="container">
-    <div class="footer__row">
-      <div class="footer__column">
-        <h2><%= t('footer.about_mapc') %></h2>
-        <p>The Metropolitan Area Planning Council (MAPC) is the regional planning agency serving the people who live and work in the 101 cities and towns of Metropolitan Boston.</p>
-      </div>
-      <div class="footer__column">
-        <h2>Quick Links</h2>
+    <div class="footer__section-about">
+      <h2><%= t('footer.about_mapc') %></h2>
+      <p>The Metropolitan Area Planning Council (MAPC) is the regional planning agency serving the people who live and work in the 101 cities and towns of Metropolitan Boston.</p>
+    </div>
+
+    <div class="footer__section-links">
+    <h2>Quick Links</h2>
         <ul>
           <li><a href="/">Home</a></li>
           <li><a href="/process-details">Process Details</a></li>
@@ -14,8 +14,8 @@
           <li><a href="<%= (Mobility.locale != Refinery::I18n.config.default_locale ? "/#{Mobility.locale.to_s}" : "") %>/privacy-policy"><%= t('footer.privacy_policy') %></a></li>
         </ul>
       </div>
-      <div class="footer__column">
-        <h2>Explore</h2>
+    <div class="footer__section-explore">
+      <h2>Explore</h2>
         <ul>
           <li><a rel="noopener noreferrer" target="_blank" href="https://www.mapc.org/about-mapc/staff/">Staff</a></li>
           <li><a rel="noopener noreferrer" target="_blank" href="https://www.mapc.org/get-involved/metrofuture-our-regional-plan/">MetroFuture</a></li>
@@ -24,17 +24,29 @@
           <li><a rel="noopener noreferrer" target="_blank" href="https://trailmap.mapc.org/">Trailmap</a></li>
         </ul>
       </div>
-      <div class="footer__column">
-        <h2>Contact Us</h2>
-        <address>
-          60 Temple Pl.<br>
-          Boston MA 02111<br>
-          <a href="tel:6179330700">617-933-0700</a>
-        </address>
-        <a href="/">metrocommon.mapc.org</a>
-      </div>
+
+    <div class="footer__section-contact">
+      <h2>Contact Us</h2>
+      <address>
+        60 Temple Pl.<br>
+        Boston MA 02111<br>
+        <a href="tel:6179330700">617-933-0700</a>
+      </address>
+      <a href="/">metrocommon.mapc.org</a>
     </div>
-    <div class="footer__row">
+
+
+   
+    <div class="footer_section-images-logo">
+      </div>
+       <%= image_tag("mapc-logo.svg", class: "footer_section-images-logo", alt: t('logo_alt')) %>
+     <% end %>
+    </div>
+
+    <div class="footer__section-images-cta">
+      <a class="button" rel="noopener noreferrer" href="<%= CONSTANT_CONTACT_LANDING_PAGE %>" target="_blank">Receive Updates</a>
+    </div>
+    <div class="footer__section-images-social">
       <div class="footer__column">
         <%= link_to 'https://www.mapc.org/', class: 'footer-mapc-brand' do %>
           <%= image_tag("mapc-logo.svg", class: "logo", alt: t('logo_alt')) %>
@@ -46,11 +58,10 @@
       <div class="footer__column">
       </div>
       <div class="footer__column footer__column--social">
-        <a aria-label="MAPC Twitter Page" href="https://twitter.com/mapcmetroboston"><%= fa_icon "twitter" %></a>
-        <a aria-label="MAPC Instagram Page" href="https://www.instagram.com/mapcmetroboston"><%= fa_icon "instagram" %></a>
-        <a aria-label="MAPC Facebook Page" href="https://www.facebook.com/mapcmetroboston"><%= fa_icon "facebook" %></a>
-        <a aria-label="MAPC LinkedIn Page" href="https://www.linkedin.com/company/metropolitan-area-planning-council/"><%= fa_icon "linkedin" %></a>
-      </div>
+      <a aria-label="MAPC Twitter Page" href="https://twitter.com/mapcmetroboston"><%= fa_icon "twitter" %></a>
+      <a aria-label="MAPC Instagram Page" href="https://www.instagram.com/mapcmetroboston"><%= fa_icon "instagram" %></a>
+      <a aria-label="MAPC Facebook Page" href="https://www.facebook.com/mapcmetroboston"><%= fa_icon "facebook" %></a>
+      <a aria-label="MAPC LinkedIn Page" href="https://www.linkedin.com/company/metropolitan-area-planning-council/"><%= fa_icon "linkedin" %></a>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
Resolves #364 (in part).

# Why is this change necessary?
The footer across all MetroCommon pages did not previously display correctly on mobile phone screen sizes.

# How does it address the issue?
`@include media(medium)` queries cover most tablets and below. I refactored the original HTML so that the sections of the footer would work with CSS Grid as opposed to Flexbox. Once a screen reaches a certain size, the grid lines are re-drawn. I also added specific `-ms` rules to make the grid IE11-compatible.

# What side effects does it have?
Utilizing CSS Grid required me to refactor the structure in `app > views > refinery > _footer.html.erb`, so any future/additional CSS stylings or JavaScript rules will need to refer to the new class names. I tried following BEM rules to the best of my understanding for these new class names, but would appreciate guidance if I missed the mark.
