### PR TITLE
Att/360 event prompt style fix

### DIFF
--- a/app/assets/stylesheets/components/grid.scss
+++ b/app/assets/stylesheets/components/grid.scss
@@ -39,5 +39,9 @@
 
       & > * { height: 100%; }
     }
+
+    @include media(small){
+      height: 3.25rem;
+    }
   }
 }

--- a/app/assets/stylesheets/components/styled-box.scss
+++ b/app/assets/stylesheets/components/styled-box.scss
@@ -67,6 +67,12 @@
   }
 
   &__title {
+    width: 75%;
+    p { color: $color_font-light; }
+    @include media(small) {
+      width: initial;
+    }
+
     display: inline-block;
     top: 2rem;
     z-index: 2;
@@ -167,6 +173,10 @@
     padding: 1.5rem 0;
     background-size: cover;
     background-repeat: no-repeat;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     &::before {
       transform: scaleY(2) rotate(-90deg);

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -1,52 +1,57 @@
 .event-box {
+  @include media(medium) { padding: 1rem 1.3rem; }
+  @include media(small) { padding: .4rem .5rem; }
+  
   padding: 2.1rem 1.8rem;
   border: 1px solid $v3-color_green-light;
   overflow: hidden;
 
-  @include media(medium) { padding: 1rem 1.3rem; }
-  @include media(small) { padding: .4rem .5rem; }
-
   &__header {
+    @include media(medium) { justify-content: center; }
+
     display: flex;
     width: 100%;
 
     h2 {
+      @media (max-width: 1399px){ font-size: 3rem; }
+      @media (max-width: 1399px) and (min-width: 1200px){ font-size: 2.5rem; }
+      @media (max-width: 1199px) and (min-width: 1024px){ font-size: 2rem; }
+      @media (max-width: 1023px) and (min-width: 961px){ font-size: 1.5rem; }
+      @media (max-width: 960px) and (min-width: 671px) { font-size: $v3_font_size-title; }
+      @media (max-width: 670px) and (min-width: 323px) { font-size: $font_size-small; }
+      @media (max-width: 322px) { font-size: 0.95rem }
+
       margin: 0;
       color: $color_font-light;
       font-size: $v3_font_size-title;
-
-      @include media(medium) {
-        padding-top: 0rem;
-        font-size: $font_size-small;
-      }
     }
 
     &::after {
+      @media (max-width: 1399px){ align-self: center; }
+
+      @media (max-width: 670px){
+        @include triangle(25px, 'right', $v3-color_green-light);
+      }
+
       @extend ._pseudo;
       @include triangle(50px, 'right', $v3-color_green-light);
 
       margin-left: 1rem;
-
-      @include media(medium) {
-        @include triangle(25px, 'right', $v3-color_green-light);
-      }
-      @include media(small){
-        margin-top: .5rem;
-      }
-    }
-
-    @include media(medium) {
-      justify-content: center;
     }
   }
 
   ul {
-    margin-top: 1.5rem;
-    overflow-y: auto;
-    max-width: 16.05rem;
-    max-height: 9.25rem;
+    @media (min-width: 1400px){
+      overflow-y: auto;
+      width: 100%;
+      max-height: 60%;
+    }
 
-    @include media(small) { display: none; }
+    @media (max-width: 1399px) and (min-width: 961px){ display: none;}
+    @media (max-width: 670px){ display: none; }
+
+    display: inline-block;
+    margin-top: 1.5rem;
   }
 
   li {
@@ -60,10 +65,10 @@
     }
 
     h4 {
+      @include media(small) { font-size: $font_size-small; }
+      
       margin: 0;
       font-weight: $font_weight-normal;
-
-      @include media(small) { font-size: $font_size-small; }
     }
   }
 

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -42,6 +42,9 @@
 
   ul {
     margin-top: 1.5rem;
+    overflow-y: auto;
+    max-width: 16.05rem;
+    max-height: 9.25rem;
 
     @include media(small) { display: none; }
   }

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -1,57 +1,45 @@
 .event-box {
   @include media(medium) { padding: 1rem 1.3rem; }
   @include media(small) { padding: .4rem .5rem; }
-  
-  padding: 2.1rem 1.8rem;
   border: 1px solid $v3-color_green-light;
   overflow: hidden;
+  padding: 2.1rem 1.8rem;
 
   &__header {
-    @include media(medium) { justify-content: center; }
+    @media (max-width: 1400px) { font-size: $font-size-xlarge; }
+    @media (max-width: 1200px) { font-size: $font-size-large; }
+    @media (max-width: 960px) {
+      font-size: $font-size-xlarge;
+      justify-content: center;
+    }
+    @media (max-width: 670px) { font-size: $font_size-small; }
+    @media (max-width: 320px) { font-size: $font_size-xsmall; }
 
+    color: $color_font-light;
     display: flex;
+    font-size: 1.8rem;
+    margin: 0;
     width: 100%;
 
-    h2 {
-      @media (max-width: 1399px){ font-size: 3rem; }
-      @media (max-width: 1399px) and (min-width: 1200px){ font-size: 2.5rem; }
-      @media (max-width: 1199px) and (min-width: 1024px){ font-size: 2rem; }
-      @media (max-width: 1023px) and (min-width: 961px){ font-size: 1.5rem; }
-      @media (max-width: 960px) and (min-width: 671px) { font-size: $v3_font_size-title; }
-      @media (max-width: 670px) and (min-width: 323px) { font-size: $font_size-small; }
-      @media (max-width: 322px) { font-size: 0.95rem }
-
-      margin: 0;
-      color: $color_font-light;
-      font-size: $v3_font_size-title;
-    }
-
     &::after {
-      @media (max-width: 1399px){ align-self: center; }
-
-      @media (max-width: 670px){
-        @include triangle(25px, 'right', $v3-color_green-light);
-      }
-
+      @media (max-width: 1399px) { align-self: center; }
+      @media (max-width: 670px) { @include triangle(25px, 'right', $v3-color_green-light); }
       @extend ._pseudo;
       @include triangle(50px, 'right', $v3-color_green-light);
-
       margin-left: 1rem;
     }
   }
 
   ul {
-    @media (min-width: 1400px){
-      overflow-y: auto;
-      width: 100%;
-      max-height: 60%;
-    }
-
-    @media (max-width: 1399px) and (min-width: 961px){ display: none;}
-    @media (max-width: 670px){ display: none; }
-
     display: inline-block;
     margin-top: 1.5rem;
+    @media (min-width: 1400px) {
+      max-height: 9.25rem;
+      overflow-y: auto;
+      width: 100%;
+    }
+    @media (max-width: 1399px) and (min-width: 961px) { display: none; }
+    @media (max-width: 670px) { display: none; }
   }
 
   li {
@@ -66,24 +54,22 @@
 
     h4 {
       @include media(small) { font-size: $font_size-small; }
-      
-      margin: 0;
       font-weight: $font_weight-normal;
+      margin: 0;
     }
   }
 
   &__event-info {
     @include media(small) { font-size: $font_size-xsmall; }
 
-    span:last-of-type {
-      $spacing: 3px;
-
-      display: inline-block;
-
-      padding-left: $spacing * 2;
-      margin-left: $spacing;
-
-      border-left: 1px solid $color_font-light;
+    span {
+      :last-of-type {
+        $spacing: 3px;
+        border-left: 1px solid $color_font-light;
+        display: inline-block;
+        margin-left: $spacing;
+        padding-left: $spacing * 2;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -1,10 +1,8 @@
 .event-box {
-  padding: 2.1rem 1.8rem;
-  border: 1px solid $v3-color_green-light;
-  overflow: hidden;
-
   @include media(medium) { padding: 1rem 1.3rem; }
   @include media(small) { padding: .4rem .5rem; }
+  
+  padding: 2.1rem 1.8rem;
   border: 1px solid $v3-color_green-light;
   overflow: hidden;
   padding: 2.1rem 1.8rem;
@@ -25,9 +23,27 @@
     margin: 0;
     width: 100%;
 
+    h2 {
+      @media (max-width: 1399px){ font-size: 3rem; }
+      @media (max-width: 1399px) and (min-width: 1200px){ font-size: 2.5rem; }
+      @media (max-width: 1199px) and (min-width: 1024px){ font-size: 2rem; }
+      @media (max-width: 1023px) and (min-width: 961px){ font-size: 1.5rem; }
+      @media (max-width: 960px) and (min-width: 671px) { font-size: $v3_font_size-title; }
+      @media (max-width: 670px) and (min-width: 323px) { font-size: $font_size-small; }
+      @media (max-width: 322px) { font-size: 0.95rem }
+      margin: 0;
+
+      color: $color_font-light;
+      font-size: $v3_font_size-title;
+    }
+
     &::after {
-      @media (max-width: 1399px) { align-self: center; }
-      @media (max-width: 670px) { @include triangle(25px, 'right', $v3-color_green-light); }
+      @media (max-width: 1399px){ align-self: center; }
+
+      @media (max-width: 670px){
+        @include triangle(25px, 'right', $v3-color_green-light);
+      }
+
       @extend ._pseudo;
       @include triangle(50px, 'right', $v3-color_green-light);
       margin-left: 1rem;
@@ -37,13 +53,17 @@
   ul {
     display: inline-block;
     margin-top: 1.5rem;
-    @media (min-width: 1400px) {
+    @media (min-width: 1400px){
       max-height: 9.25rem;
       overflow-y: auto;
       width: 100%;
+      max-height: 60%;
     }
-    @media (max-width: 1399px) and (min-width: 961px) { display: none; }
-    @media (max-width: 670px) { display: none; }
+    @media (max-width: 1399px) and (min-width: 961px){ display: none;}
+    @media (max-width: 670px){ display: none; }
+
+    display: inline-block;
+    margin-top: 1.5rem;
   }
 
   li {
@@ -57,12 +77,13 @@
     }
 
     h4 {
+      @include media(small) { font-size: $font_size-small; }
+      
       margin: 0;
       font-weight: $font_weight-normal;
 
       @include media(small) { font-size: $font_size-small; }
       font-weight: $font_weight-normal;
-      margin: 0;
     }
   }
 

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -1,4 +1,8 @@
 .event-box {
+  padding: 2.1rem 1.8rem;
+  border: 1px solid $v3-color_green-light;
+  overflow: hidden;
+
   @include media(medium) { padding: 1rem 1.3rem; }
   @include media(small) { padding: .4rem .5rem; }
   border: 1px solid $v3-color_green-light;
@@ -53,6 +57,9 @@
     }
 
     h4 {
+      margin: 0;
+      font-weight: $font_weight-normal;
+
       @include media(small) { font-size: $font_size-small; }
       font-weight: $font_weight-normal;
       margin: 0;

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -4,6 +4,7 @@
   overflow: hidden;
 
   @include media(medium) { padding: 1rem 1.3rem; }
+  @include media(small) { padding: .4rem .5rem; }
 
   &__header {
     display: flex;
@@ -28,6 +29,9 @@
 
       @include media(medium) {
         @include triangle(25px, 'right', $v3-color_green-light);
+      }
+      @include media(small){
+        margin-top: .5rem;
       }
     }
 

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -1,8 +1,6 @@
 .event-box {
   @include media(medium) { padding: 1rem 1.3rem; }
   @include media(small) { padding: .4rem .5rem; }
-  
-  padding: 2.1rem 1.8rem;
   border: 1px solid $v3-color_green-light;
   overflow: hidden;
   padding: 2.1rem 1.8rem;
@@ -23,27 +21,9 @@
     margin: 0;
     width: 100%;
 
-    h2 {
-      @media (max-width: 1399px){ font-size: 3rem; }
-      @media (max-width: 1399px) and (min-width: 1200px){ font-size: 2.5rem; }
-      @media (max-width: 1199px) and (min-width: 1024px){ font-size: 2rem; }
-      @media (max-width: 1023px) and (min-width: 961px){ font-size: 1.5rem; }
-      @media (max-width: 960px) and (min-width: 671px) { font-size: $v3_font_size-title; }
-      @media (max-width: 670px) and (min-width: 323px) { font-size: $font_size-small; }
-      @media (max-width: 322px) { font-size: 0.95rem }
-      margin: 0;
-
-      color: $color_font-light;
-      font-size: $v3_font_size-title;
-    }
-
     &::after {
-      @media (max-width: 1399px){ align-self: center; }
-
-      @media (max-width: 670px){
-        @include triangle(25px, 'right', $v3-color_green-light);
-      }
-
+      @media (max-width: 1399px) { align-self: center; }
+      @media (max-width: 670px) { @include triangle(25px, 'right', $v3-color_green-light); }
       @extend ._pseudo;
       @include triangle(50px, 'right', $v3-color_green-light);
       margin-left: 1rem;
@@ -53,17 +33,13 @@
   ul {
     display: inline-block;
     margin-top: 1.5rem;
-    @media (min-width: 1400px){
+    @media (min-width: 1400px) {
       max-height: 9.25rem;
       overflow-y: auto;
       width: 100%;
-      max-height: 60%;
     }
-    @media (max-width: 1399px) and (min-width: 961px){ display: none;}
-    @media (max-width: 670px){ display: none; }
-
-    display: inline-block;
-    margin-top: 1.5rem;
+    @media (max-width: 1399px) and (min-width: 961px) { display: none; }
+    @media (max-width: 670px) { display: none; }
   }
 
   li {
@@ -78,12 +54,8 @@
 
     h4 {
       @include media(small) { font-size: $font_size-small; }
-      
+      font-weight: $font_weight-normal;
       margin: 0;
-      font-weight: $font_weight-normal;
-
-      @include media(small) { font-size: $font_size-small; }
-      font-weight: $font_weight-normal;
     }
   }
 

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -29,6 +29,7 @@
     }
 
     .styled-box {
+
       padding: 0;
       text-align: center;
       cursor: default;
@@ -60,33 +61,29 @@
 
       @include media(medium) {
         &__content {
-          display: grid;
-          grid-template-columns: 348px;
-          grid-template-rows: 65px auto auto auto auto;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
           margin: 0;
           background-image: none;
 
-          h1 {
-            grid-column-start: 1;
-            margin: 0;
-          }
+          h1 { margin: 0; }
 
           .sub-header {
-            grid-column-start: 1;
             font-size: 17px;
             font-display: italic;
             width: 236px;
           }
 
           p {
-            grid-column-start: 1;
             font-size: 16px;
             width: 345px;
           }
 
           .hero-banner-actions {
-            grid-column-start: 1;
             margin: 0;
+            width: 345px;
+            //align-self: center;
           }
 
           a.button {
@@ -103,6 +100,16 @@
             margin: 0 0 1rem 0;
             width: 100%;
           }
+        }
+      }
+      @media (max-width: 425px){
+        .hero-banner-actions{
+          align-self: center;
+        }
+      }
+      @media (max-width: 374px){
+        p, .hero-banner-actions {
+          width: 275px;
         }
       }
     }

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -5,6 +5,7 @@ $(() => {
   }
   fetchTaggings(allTaggings)
   loadDropdowns()
+  $('title')[0].text = 'MetroCommon x 2050'
 })
 
 function loadDropdowns() {

--- a/app/views/partials/_event_box.html.erb
+++ b/app/views/partials/_event_box.html.erb
@@ -1,10 +1,7 @@
 <% events = events[0..2] if events.size > 3 %>
 
 <div class="event-box">
-  <div class="event-box__header">
-    <h2>Join us for <br> an event!</h2>
-  </div>
-
+  <h2 class="event-box__header">Join us for <br> an event!</h2>
   <% if events.size > 0 %>
     <ul>
       <% events.each do |event| %>

--- a/app/views/partials/_one_box.html.erb
+++ b/app/views/partials/_one_box.html.erb
@@ -5,7 +5,7 @@
   class="styled-box one-box <%= 'styled-box--half' if type == 'half' %>"
   style="background-image: url('<%= image_path(image) %>')"
 >
-  <div class="styled-box__content">
+  
     <div class="styled-box__title styled-box__title--block"><%= title %></div>
-  </div>
+
 </div>

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -4,7 +4,9 @@
       <div class="content container">
         <div class="content__title"><%= @announcement.title %></div>
         <div class="content__content-type">NEWS</div>
-        <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
+        <% if @announcement.published_date %>
+          <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
+        <% end %>
         <div class="content__tags">Tags: <%= @tags %></div>
         <div class="content__body">
           <img src="<%= @image_url %>" class="content__image" />


### PR DESCRIPTION
Resolves #360 .

# Why is this change necessary?
- Homepage needed to match XD file for mobile
- Events with titles that expanded beyond the first line were throwing off the events box margins

# How does it address the issue?
- Media queries address various breakpoints and adjust different parts of the homepage (card size, font size, div width).
- Scroll capabilities in the event box allow for event titles of arbitrary length

# What side effects does it have?
Because I needed media queries for multiple aspects of the page, not every screen width matches either the mobile or desktop XD prototype pixel-for-pixel. I tried to keep the spirit of the designs in mind at every view, but feedback on how various views may be better implemented is very welcome.
