### PR TITLE
Resolve #366 Dynamic Header and Display Height

### DIFF
--- a/app/assets/stylesheets/refinery/find_out.scss
+++ b/app/assets/stylesheets/refinery/find_out.scss
@@ -26,6 +26,7 @@
 
     background-image: image-url('group-2111.png');
     height: 29.05rem;
+    margin-bottom: 2rem;
   }
 
   .filter {

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -82,7 +82,7 @@ const fetchTaggings = (dropdownsObject) => {
     dataType: 'json',
     data: dropdownsObject,
   }).done(response => {
-    const resultsDiv = $('.results.container')
+    const resultsDiv = $('.results')
     const headerShort = () => {
       $('.find-out__header').css('height', '29.05rem')
     }
@@ -99,6 +99,7 @@ const fetchTaggings = (dropdownsObject) => {
 
     const cardsHigh = () => {
       resultsDiv.css('bottom', '14rem')
+      resultsDiv.css('margin-bottom', '-18rem')
     }
 
     const cardsLow = () => {
@@ -108,6 +109,7 @@ const fetchTaggings = (dropdownsObject) => {
     const resetDisplay = () => {
       $('.narrative-text').empty()
       resultsDiv.empty()
+      resultsDiv.css('margin-bottom', '0rem')
     }
 
     resetDisplay()
@@ -342,7 +344,7 @@ Announcement.prototype.announcementCardHtml = function announcementCardHtml() {
       <div class="card__title">
         <a class="card__link" href="/announcements/${this.id}">${this.title}</a>
       </div>
-      <div class="card--tags">
+      <div class="card__tags">
         tags: ${tagsHtml}
       </div>
     </div>


### PR DESCRIPTION
Resolves #366

# Why is this change necessary?
There were additional style changes required to improve the UX.

# How does it address the issue?
Most of this issue was already solved with the merge of the large pull request on 8/14/2019.
This PR adds the following:
* Add bottom margin to header narrative section to accommodate longer narrative texts
* Refine `resultsDiv` selector to `.results` class
* When display cards are in the raised position, a negative `margin-bottom` now removes excess space between the cards and the footer.
* Fix typo in display card, tags selector. All are now  styled the same (Announcement, Event, Report)

# What side effects does it have?
The dynamic sizing of the display cards area is controlled by a combination of Javascript and CSS Flexbox. So a side effect is that editing CSS rules might not always work as expected unless you examine what the javascript is doing to manipulate style dynamically.
