### PR TITLE
Resolve #391 Template Fails w/o published_date

### DIFF
--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -4,7 +4,9 @@
       <div class="content container">
         <div class="content__title"><%= @announcement.title %></div>
         <div class="content__content-type">NEWS</div>
-        <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
+        <% if @announcement.published_date %>
+          <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
+        <% end %>
         <div class="content__tags">Tags: <%= @tags %></div>
         <div class="content__body">
           <img src="<%= @image_url %>" class="content__image" />


### PR DESCRIPTION
This adds a conditional to only display the time of the published_date if that field is populated. Otherwise we fall back to displaying only the other attributes in our view.
