### PR TITLE
Resolve #362 Change browser title

### DIFF
--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -5,6 +5,7 @@ $(() => {
   }
   fetchTaggings(allTaggings)
   loadDropdowns()
+  $('title')[0].text = 'MetroCommon x 2050'
 })
 
 function loadDropdowns() {


### PR DESCRIPTION
* Add jquery statement to change page title to MetroCommon x 2050

Resolves #362 

# Why is this change necessary?
The find-out page was displaying a title of:  `Taggings - Metropolitan Area Planning Council`
Expected title:  `MetroCommon x 2050

# How does it address the issue?
A jquery line of code changes the page title upon page load.

# What side effects does it have?
None.