### PR TITLE
Att/364 mobile styling find out header

### DIFF
--- a/app/assets/stylesheets/components/grid.scss
+++ b/app/assets/stylesheets/components/grid.scss
@@ -39,5 +39,9 @@
 
       & > * { height: 100%; }
     }
+
+    @include media(small){
+      height: 3.25rem;
+    }
   }
 }

--- a/app/assets/stylesheets/components/styled-box.scss
+++ b/app/assets/stylesheets/components/styled-box.scss
@@ -67,6 +67,12 @@
   }
 
   &__title {
+    width: 75%;
+    p { color: $color_font-light; }
+    @include media(small) {
+      width: initial;
+    }
+
     display: inline-block;
     top: 2rem;
     z-index: 2;
@@ -167,6 +173,10 @@
     padding: 1.5rem 0;
     background-size: cover;
     background-repeat: no-repeat;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
 
     &::before {
       transform: scaleY(2) rotate(-90deg);

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -1,44 +1,45 @@
 .event-box {
   @include media(medium) { padding: 1rem 1.3rem; }
+  @include media(small) { padding: .4rem .5rem; }
   border: 1px solid $v3-color_green-light;
   overflow: hidden;
   padding: 2.1rem 1.8rem;
 
   &__header {
+    @media (max-width: 1400px) { font-size: $font-size-xlarge; }
+    @media (max-width: 1200px) { font-size: $font-size-large; }
+    @media (max-width: 960px) {
+      font-size: $font-size-xlarge;
+      justify-content: center;
+    }
+    @media (max-width: 670px) { font-size: $font_size-small; }
+    @media (max-width: 320px) { font-size: $font_size-xsmall; }
+
+    color: $color_font-light;
     display: flex;
+    font-size: 1.8rem;
+    margin: 0;
     width: 100%;
 
-    h2 {
-      @include media(medium) {
-        padding-top: 0rem;
-        font-size: $font_size-small;
-      }
-      
-      color: $color_font-light;
-      font-size: $v3_font_size-title;
-      margin: 0;
-    }
-
     &::after {
+      @media (max-width: 1399px) { align-self: center; }
+      @media (max-width: 670px) { @include triangle(25px, 'right', $v3-color_green-light); }
       @extend ._pseudo;
       @include triangle(50px, 'right', $v3-color_green-light);
-
       margin-left: 1rem;
-
-      @include media(medium) {
-        @include triangle(25px, 'right', $v3-color_green-light);
-      }
-    }
-
-    @include media(medium) {
-      justify-content: center;
     }
   }
 
   ul {
+    display: inline-block;
     margin-top: 1.5rem;
-
-    @include media(small) { display: none; }
+    @media (min-width: 1400px) {
+      max-height: 9.25rem;
+      overflow-y: auto;
+      width: 100%;
+    }
+    @media (max-width: 1399px) and (min-width: 961px) { display: none; }
+    @media (max-width: 670px) { display: none; }
   }
 
   li {
@@ -52,25 +53,23 @@
     }
 
     h4 {
-      margin: 0;
-      font-weight: $font_weight-normal;
-
       @include media(small) { font-size: $font_size-small; }
+      font-weight: $font_weight-normal;
+      margin: 0;
     }
   }
 
   &__event-info {
     @include media(small) { font-size: $font_size-xsmall; }
 
-    span:last-of-type {
-      $spacing: 3px;
-
-      display: inline-block;
-
-      padding-left: $spacing * 2;
-      margin-left: $spacing;
-
-      border-left: 1px solid $color_font-light;
+    span {
+      :last-of-type {
+        $spacing: 3px;
+        border-left: 1px solid $color_font-light;
+        display: inline-block;
+        margin-left: $spacing;
+        padding-left: $spacing * 2;
+      }
     }
   }
 }

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -1,23 +1,22 @@
 .event-box {
-  padding: 2.1rem 1.8rem;
+  @include media(medium) { padding: 1rem 1.3rem; }
   border: 1px solid $v3-color_green-light;
   overflow: hidden;
-
-  @include media(medium) { padding: 1rem 1.3rem; }
+  padding: 2.1rem 1.8rem;
 
   &__header {
     display: flex;
     width: 100%;
 
     h2 {
-      margin: 0;
-      color: $color_font-light;
-      font-size: $v3_font_size-title;
-
       @include media(medium) {
         padding-top: 0rem;
         font-size: $font_size-small;
       }
+      
+      color: $color_font-light;
+      font-size: $v3_font_size-title;
+      margin: 0;
     }
 
     &::after {

--- a/app/assets/stylesheets/refinery/find_out.scss
+++ b/app/assets/stylesheets/refinery/find_out.scss
@@ -42,6 +42,7 @@
       font-family: $font_family-primary;
       font-size: $v3_font_size-title;
     }
+    @include media(x-small) { font-size: $v3_font_size-h1-mobile; }
     color: $v3_color_bg-lightest;
     display: inline-block;
     font-family: $font_family-primary;
@@ -56,9 +57,8 @@
     }
 
     &__select {
-      @include media(small) {
-        font-size: $v3_font_size-title;
-      }
+      @include media(small) { font-size: $v3_font_size-title; }
+      @include media(x-small) { font-size: $v3_font_size-h1-mobile; }
 
       appearance: none;
       border: 0;

--- a/app/assets/stylesheets/refinery/find_out.scss
+++ b/app/assets/stylesheets/refinery/find_out.scss
@@ -1,17 +1,17 @@
 .FindOut {
   .banner {
     @include background-2x('find-out-banner', 'png', fit, fit, center, no-repeat);
-    @include media(small) {
-      background-position: bottom 3rem right;
-    }
+    @include media(small) { background-position: bottom 3rem right; }
     background: $color_bg-dark;
     background-position: center;
     background-repeat: no-repeat;
     background-size: fit;
   }
 
-  .container::after {
-    display: none;
+  .container {
+    &::after {
+      display: none;
+    }
   }
 
   .banner-content {
@@ -20,22 +20,28 @@
   }
 
   .find-out__header {
-    @include media(small) {
-      background: none;
-    }
+    @include media(small) { background: none; }
     align-items: center;
     background-image: image-url('group-2111.png');
     display: flex;
+    height: 29rem;
     justify-content: center;
     min-height: 29.05rem;
   }
 
-  .content-type {
+  .form {
+    @include media(large) { max-width: 38rem; }
+    @include media(small) {max-width: 29rem;}
+    @include media(x-small) { max-width: 17rem; }
+    width: 49rem;
+  }
+
+  .content-type,
+  .topic-area {
     @include media(small) {
       font-family: $font_family-primary;
       font-size: $v3_font_size-title;
     }
-
     color: $v3_color_bg-lightest;
     display: inline-block;
     font-family: $font_family-primary;
@@ -51,50 +57,7 @@
 
     &__select {
       @include media(small) {
-        font-size: $font_size-large;
-      }
-
-      appearance: none;
-      border: 0;
-      outline: none;
-      text-decoration: underline;
-
-      &:hover {
-        color: $v3-color_green-light;
-        cursor: pointer;
-
-        &:focus {
-          color: $v3_color_bg-lightest;
-          cursor: pointer;
-        }
-      }
-    }
-  }
-
-  .topic-area {
-    @include media(small) {
-      font-family: $font_family-primary;
-      font-size: $v3_font_size-title;
-    }
-
-    color: $v3_color_bg-lightest;
-    display: block;
-    //float: left;
-    font-family: $font_family-primary;
-    font-size: $v3_font_size-h1;
-    width: auto;
-
-    &__dropdown {
-      appearance: none;
-      background: none;
-      border: 0;
-      display: inline;
-      text-decoration: underline;
-    }
-
-    &__select {
-      @include media(small) {
-        font-size: $font_size-large;
+        font-size: $v3_font_size-title;
       }
 
       appearance: none;
@@ -118,7 +81,7 @@
     color: $v3_color_bg-lightest;
     font-family: $font_family-primary;
     font-size: $font_size-medium;
-    //margin: 2rem 0 2.4rem 19.3rem;
+    margin: 2rem auto;
   }
 
   .next-three-events {

--- a/app/assets/stylesheets/refinery/find_out.scss
+++ b/app/assets/stylesheets/refinery/find_out.scss
@@ -1,6 +1,6 @@
 .FindOut {
   .banner {
-    @include background-2x('find-out-banner', 'png', fit, fit, center, no-repeat );
+    @include background-2x('find-out-banner', 'png', fit, fit, center, no-repeat);
     @include media(small) {
       background-position: bottom 3rem right;
     }
@@ -23,21 +23,11 @@
     @include media(small) {
       background: none;
     }
-
+    align-items: center;
     background-image: image-url('group-2111.png');
-    height: 29.05rem;
-    margin-bottom: 2rem;
-  }
-
-  .filter {
-    @include media(small) {
-      display: flex;
-      flex-direction: row;
-      flex-wrap: wrap;
-    }
-
     display: flex;
-    width: auto;
+    justify-content: center;
+    min-height: 29.05rem;
   }
 
   .content-type {
@@ -50,7 +40,6 @@
     display: inline-block;
     font-family: $font_family-primary;
     font-size: $v3_font_size-h1;
-    padding: 11.35rem 0 0 19.3rem;
 
     &__dropdown {
       appearance: none;
@@ -90,9 +79,9 @@
 
     color: $v3_color_bg-lightest;
     display: block;
+    //float: left;
     font-family: $font_family-primary;
     font-size: $v3_font_size-h1;
-    margin-left: 19.3rem;
     width: auto;
 
     &__dropdown {
@@ -129,7 +118,7 @@
     color: $v3_color_bg-lightest;
     font-family: $font_family-primary;
     font-size: $font_size-medium;
-    margin: 2rem 0 2.4rem 19.3rem;
+    //margin: 2rem 0 2.4rem 19.3rem;
   }
 
   .next-three-events {

--- a/app/assets/stylesheets/refinery/home.scss
+++ b/app/assets/stylesheets/refinery/home.scss
@@ -29,6 +29,7 @@
     }
 
     .styled-box {
+
       padding: 0;
       text-align: center;
       cursor: default;
@@ -60,33 +61,29 @@
 
       @include media(medium) {
         &__content {
-          display: grid;
-          grid-template-columns: 348px;
-          grid-template-rows: 65px auto auto auto auto;
+          display: flex;
+          flex-direction: column;
+          justify-content: center;
           margin: 0;
           background-image: none;
 
-          h1 {
-            grid-column-start: 1;
-            margin: 0;
-          }
+          h1 { margin: 0; }
 
           .sub-header {
-            grid-column-start: 1;
             font-size: 17px;
             font-display: italic;
             width: 236px;
           }
 
           p {
-            grid-column-start: 1;
             font-size: 16px;
             width: 345px;
           }
 
           .hero-banner-actions {
-            grid-column-start: 1;
             margin: 0;
+            width: 345px;
+            //align-self: center;
           }
 
           a.button {
@@ -103,6 +100,16 @@
             margin: 0 0 1rem 0;
             width: 100%;
           }
+        }
+      }
+      @media (max-width: 425px){
+        .hero-banner-actions{
+          align-self: center;
+        }
+      }
+      @media (max-width: 374px){
+        p, .hero-banner-actions {
+          width: 275px;
         }
       }
     }

--- a/app/assets/stylesheets/refinery/nice-select.scss
+++ b/app/assets/stylesheets/refinery/nice-select.scss
@@ -22,10 +22,10 @@ $arrow_color: $gray !default;
   clear: both;
   color: $v3_color_bg-lightest;
   cursor: pointer;
-  float: right;
+  //float: right;
   font-family: $font_family-primary;
   font-size: $v3_font_size-h1;
-  margin-left: .7rem;
+  //margin-left: .7rem;
   outline: none;
   padding-right: $dropdown_padding + 22;
   position: relative;
@@ -40,6 +40,10 @@ $arrow_color: $gray !default;
 
   // Arrow
   &::after {
+    @include media (small) {
+      border-bottom-width: 10px;
+      border-right-width: 10px;
+    }
     border-bottom: 18px solid $v3_color_bg-lightest;
     border-bottom-color: transparent;
     border-left-color: transparent;

--- a/app/assets/stylesheets/refinery/nice-select.scss
+++ b/app/assets/stylesheets/refinery/nice-select.scss
@@ -22,10 +22,8 @@ $arrow_color: $gray !default;
   clear: both;
   color: $v3_color_bg-lightest;
   cursor: pointer;
-  //float: right;
   font-family: $font_family-primary;
   font-size: $v3_font_size-h1;
-  //margin-left: .7rem;
   outline: none;
   padding-right: $dropdown_padding + 22;
   position: relative;
@@ -68,9 +66,17 @@ $arrow_color: $gray !default;
     }
 
     .list {
+      @include media(x-small) {
+        text-indent: -1rem;
+        white-space: pre-wrap;
+      }
       opacity: 1;
       pointer-events: auto;
       transform: scale(1) translateY(0);
+
+      li {
+        @include media(x-small) { height: auto; }
+      }
     }
   }
 
@@ -112,6 +118,7 @@ $arrow_color: $gray !default;
       height: 4px;
       width: 4px;
     }
+
     .option {
       line-height: $input_height_small - 2;
       min-height: $input_height_small - 2;

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -5,6 +5,7 @@ $(() => {
   }
   fetchTaggings(allTaggings)
   loadDropdowns()
+  $('title')[0].text = 'MetroCommon x 2050'
 })
 
 function loadDropdowns() {

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -14,13 +14,13 @@ function loadDropdowns() {
   }).done((response) => {
     const contentTypes = response.filter(tag => tag.data.attributes.tag_type === 'content_type')
     const contentTypeSelectOptions = contentTypes.slice(0, 3).map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`).join('')
-    const contentTypeDropdown = (`<select class="content-type__select"><option id='all-content-types' value='everything' selected>everything</option>${contentTypeSelectOptions}</select>`)
-    document.getElementsByClassName('content-type__dropdown')[0].innerHTML = contentTypeDropdown
+    const contentTypeDropdown = (`<select class="content-type__select content-type__dropdown"><option id='all-content-types' value='everything' selected>everything</option>${contentTypeSelectOptions}</select>`)
+    document.getElementsByClassName('content-type')[0].innerHTML = "You're looking for " + contentTypeDropdown
 
     const topicAreas = response.filter(tag => tag.data.attributes.tag_type === 'topic_area')
     const topicAreaSelectOptions = topicAreas.map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`).join('')
-    const topicAreaDropdown = (`<select class="topic-area__select"><option id='all-topic-areas' value='all topic areas' selected>all topic areas</option>${topicAreaSelectOptions}</select>`)
-    document.getElementsByClassName('topic-area__dropdown')[0].innerHTML = topicAreaDropdown
+    const topicAreaDropdown = (`<select class="topic-area__select topic-area__dropdown"><option id='all-topic-areas' value='all topic areas' selected>all topic areas</option>${topicAreaSelectOptions}</select>`)
+    document.getElementsByClassName('topic-area')[0].innerHTML = "in " + topicAreaDropdown
     onDropdownChange()
     cueOverlay()
   })

--- a/app/views/partials/_event_box.html.erb
+++ b/app/views/partials/_event_box.html.erb
@@ -1,10 +1,7 @@
 <% events = events[0..2] if events.size > 3 %>
 
 <div class="event-box">
-  <div class="event-box__header">
-    <h2>Join us for <br> an event!</h2>
-  </div>
-
+  <h2 class="event-box__header">Join us for <br> an event!</h2>
   <% if events.size > 0 %>
     <ul>
       <% events.each do |event| %>

--- a/app/views/partials/_one_box.html.erb
+++ b/app/views/partials/_one_box.html.erb
@@ -5,7 +5,7 @@
   class="styled-box one-box <%= 'styled-box--half' if type == 'half' %>"
   style="background-image: url('<%= image_path(image) %>')"
 >
-  <div class="styled-box__content">
+  
     <div class="styled-box__title styled-box__title--block"><%= title %></div>
-  </div>
+
 </div>

--- a/app/views/refinery/pages/find_out.html.erb
+++ b/app/views/refinery/pages/find_out.html.erb
@@ -6,17 +6,17 @@
   <section class="v2-banner">
     <div class="find-out__header container">
     <div id="find-out__overlay"></div>
-      <div class="container">
-        <form>
+      
+        <form class="form">
           <div class="filter">
             <div class='content-type'>You're looking for<span class="content-type__dropdown"></span></div>
           </div>
           <div class="filter">
             <div class='topic-area'>in<span class="topic-area__dropdown"></span></div>
           </div>
-          <div class="narrative-text"></div>
+          <div class="narrative-text">test</div>
         </form>
-      </div>
+
   </section>
   <div class="results container"></div>
   <div class="load-more__button">

--- a/app/views/refinery/pages/find_out.html.erb
+++ b/app/views/refinery/pages/find_out.html.erb
@@ -6,17 +6,11 @@
   <section class="v2-banner">
     <div class="find-out__header container">
     <div id="find-out__overlay"></div>
-      
-        <form class="form">
-          <div class="filter">
-            <div class='content-type'>You're looking for<span class="content-type__dropdown"></span></div>
-          </div>
-          <div class="filter">
-            <div class='topic-area'>in<span class="topic-area__dropdown"></span></div>
-          </div>
-          <div class="narrative-text">test</div>
-        </form>
-
+      <form class="form">
+        <div class='filter content-type'></div>
+        <div class='filter topic-area'></div>
+        <div class="narrative-text"></div>
+      </form>
   </section>
   <div class="results container"></div>
   <div class="load-more__button">

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -4,7 +4,9 @@
       <div class="content container">
         <div class="content__title"><%= @announcement.title %></div>
         <div class="content__content-type">NEWS</div>
-        <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
+        <% if @announcement.published_date %>
+          <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
+        <% end %>
         <div class="content__tags">Tags: <%= @tags %></div>
         <div class="content__body">
           <img src="<%= @image_url %>" class="content__image" />


### PR DESCRIPTION
Resolves #364 (partial) .

# Why is this change necessary?
The header on the Find Out page was only optimized for wide-screen viewing, so it did not reflect the XD document on smaller desktop views or match the prototype on mobile devices.

# How does it address the issue?
- `find_out.html.erb` and `find-out.js` refactored slightly to reduce extra div nesting, allowing for easier and more flexible styling
- Header styles in `find_out.scss` refactored into Flexbox to keep the text centered horizontally and vertically across multiple screen sizes

# What side effects does it have?
None, though I noticed that in rebasing prior to this PR Git is showing that I changed certain files in this iteration that I actually edited in prior branches (such as `_event-box.scss`, which I edited in resolving #380). Is that expected?

The only files I meant to edit for this particular issue were:
- `find_out.scss`
- `nice-select.scss`
- `find-out.js`
- `find-out.html.erb`
