### PR TITLE
Att/407 load more

### DIFF
--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -132,8 +132,7 @@ const fetchTaggings = (dropdownsObject) => {
       cardsLow()
       headerShort()
     }
-
-    loadInitialCards(response.taggings, resultsDiv)
+    loadInitialCards(response.taggings, resultsDiv, dropdownsObject)
     onClickOverlay()
   })
 }
@@ -156,16 +155,27 @@ const createCards = (taggings, resultsDiv) => {
   })
 }
 
-const loadInitialCards = (taggings, resultsDiv) => {
+const loadInitialCards = (taggings, resultsDiv, dropdownsObject) => {
   if (taggings.length === 0) {
     $('.results').html('<div class="message--none">There are currently no results for the selected filters.</div>')
     hideLoadMoreButton()
   } else {
-    createCards(taggings.slice(0, 9), resultsDiv)
-    if (taggings.length > 9) {
-      showLoadMoreButton(taggings.slice(9, taggings.length - 1), resultsDiv)
-    } else {
-      hideLoadMoreButton()
+    if (dropdownsObject.content_type === 'events'){
+      createCards(taggings.slice(0,8), resultsDiv)
+      if (taggings.length > 8){
+        showLoadMoreButton(taggings.slice(8, taggings.length - 1), resultsDiv)
+      }
+      else {
+        hideLoadMoreButton()
+      }
+    }
+    else{
+      createCards(taggings.slice(0, 9), resultsDiv)
+      if (taggings.length > 9) {
+        showLoadMoreButton(taggings.slice(9, taggings.length - 1), resultsDiv)
+      } else {
+        hideLoadMoreButton()
+      }
     }
   }
 }

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -189,7 +189,8 @@ const hideLoadMoreButton = () => {
 
 const showLoadMoreButton = (remainingCards, resultsDiv) => {
   $('#load-more').show()
-  $('#load-more').on('click', (event) => {
+  $('#load-more').unbind('click')
+  $('#load-more').bind('click', (event) => {
     event.preventDefault()
     loadRemainingCards(remainingCards, resultsDiv)
   })


### PR DESCRIPTION
Resolves #407 .

# Why is this change necessary?
The "Load More" button on the Find Out page was not consistently working. Specifically, when loading more events it would simply load all cards (including some repeats)

# How does it address the issue?
The root of the issue was a duplicated event listener on the `#load-more` button. By unbinding and then re-binding the click event, the event only goes through once with the correct data.

# What side effects does it have?
No side effects to the fix, but it did show that if a card is missing required attributes (specifically an image URL) then the API call logic gets thrown off.