### PR TITLE
408: mobile styling for report and announcement pages

### DIFF
--- a/app/assets/stylesheets/partials/_header.scss
+++ b/app/assets/stylesheets/partials/_header.scss
@@ -1,9 +1,9 @@
 header {
-  width: 100%;
-  position: absolute;
   left: 0;
-  right: 0;
   margin: 0;
+  position: absolute;
+  right: 0;
+  width: 100%;
   z-index: 100;
 
   h1 {
@@ -11,13 +11,13 @@ header {
   }
 
   .language-disclaimer {
-    color: $color_font-light;
     background-color: $color_bg-black;
-    width: 100%;
+    color: $color_font-light;
     font-size: $font_size-xsmall;
+    width: 100%;
     .container {
-      padding-top: 0.5rem;
-      padding-bottom: 0.5rem;
+      padding-bottom: .5rem;
+      padding-top: .5rem;
     }
   }
 
@@ -25,7 +25,7 @@ header {
     display: flex;
     flex-wrap: nowrap;
     justify-content: space-between;
-    padding: 1rem 2rem;
+    padding-top: 1rem;
 
     @include media(medium) {
       padding: 1rem 1.35rem;
@@ -37,14 +37,14 @@ header {
   }
 
   .site-name {
+    align-items: center;
     color: $color_font-light;
     display: flex;
-    align-items: center;
     img.wordmark {
-      height: $font_size-small;
       @include media(x-small) {
         height: $font_size-xsmall;
       }
+      height: $font_size-small;
     }
   }
 

--- a/app/assets/stylesheets/refinery/announcement.scss
+++ b/app/assets/stylesheets/refinery/announcement.scss
@@ -11,77 +11,92 @@
     }
   }
 
-  .content {
-    display: grid;
-    grid-auto-flow: dense;
-    grid-template-columns: 6rem 1fr 6rem;
-
-    &__content-type {
+  .container {
+    @include media (small) {
+      display: grid;
+      margin: 0;
+      padding: 0;
+    }
+    .content__content-type {
+      @include media (small) {
+        grid-row: 2;
+        margin-top: 1rem;
+        padding: 1rem 1.35rem 0;
+      }
       appearance: none;
       color: $v3-color_gray-dark;
       font-family: $font_family-secondary;
       font-size: $font_size-small;
-      grid-column-start: 2;
       grid-row-start: 1;
       letter-spacing: .2rem;
-      margin-top: 5rem;
       padding: 1rem 0 0;
       text-transform: uppercase;
     }
 
-    &__date {
+    .content__date {
+      @include media(small) {
+        grid-row: 4;
+        padding: 1rem 1.35rem 0;
+      }
       appearance: none;
       color: $v3-color_gray-dark;
       font-family: $font_family-secondary-light;
       font-size: $font_size-small;
-      grid-column-start: 2;
-      grid-row-start: 2;
       padding: 1rem 0 0;
     }
 
-    &__title {
+    .content__title {
+      @include media(small) {
+        grid-row: 3;
+        padding: .5rem 1.35rem 0;
+      }
       color: $v3-color_green-medium;
       font-family: $font_family-primary;
       font-size: $font_size-xlarge;
-      grid-column-start: 2;
-      grid-row-start: 3;
       padding: .5rem 0 0;
     }
 
-    &__tags {
+    .content__tags {
+      @include media(small) {
+        grid-row: 5;
+        padding: .5rem 1.35rem 0;
+      }
       color: $color_bg-darkgrey;
       font-family: $font_family-primary;
       font-size: $font_size-small;
       font-style: italic;
-      grid-column-start: 2;
-      grid-row-start: 4;
       padding: .5rem 0;
     }
 
-    &__body {
+    .content__body {
+      @include media (small) {
+        grid-row: 6;
+        margin-bottom: 1rem;
+        min-height: unset;
+        padding: .5rem 1.35rem 1rem;
+      }
       color: $v3-color_gray-dark;
       font-size: $font_size-small;
-      grid-column-end: 3;
-      grid-column-start: 2;
-      grid-row-start: 5;
       line-height: 1.5rem;
-      margin-bottom: 5rem;
-      padding: .5rem 0;
+      min-height: 27.85rem;
+      padding: .5rem 0 1rem;
     }
 
-    &__image {
+    .content__image {
       @include media(small) {
-        display: block;
-        float: none;
+        float: unset;
+        grid-row: 1;
+        margin: 0;
+        max-height: 20rem;
+        max-width: unset;
+        padding: 0;
+        width: 100%;
       }
-
       float: right;
-      grid-column-start: 2;
-      grid-row-start: 5;
       height: auto;
-      margin: 0 0 .6rem .8rem;
-      padding: 0 0 1rem 1rem;
-      width: 40vw;
+      margin: 10.25rem 0 .6rem .8rem;
+      max-width: 30rem;
+      padding: 0 1.35rem 1rem 1rem;
     }
   }
 }

--- a/app/assets/stylesheets/refinery/report.scss
+++ b/app/assets/stylesheets/refinery/report.scss
@@ -11,77 +11,93 @@
     }
   }
 
-  .content {
-    display: grid;
-    grid-auto-flow: dense;
-    grid-template-columns: 6rem 1fr 6rem;
-
-    &__content-type {
+  .container {
+    @include media(small) {
+      display: grid;
+      margin: 0;
+      padding: 0;
+    }
+    
+    .content__content-type {
+      @include media (small) {
+        grid-row: 2;
+        margin-top: 1rem;
+        padding: 1rem 1.35rem 0;
+      }
       appearance: none;
       color: $v3-color_gray-dark;
       font-family: $font_family-secondary;
       font-size: $font_size-small;
-      grid-column-start: 2;
       grid-row-start: 1;
       letter-spacing: .2rem;
-      margin-top: 5rem;
       padding: 1rem 0 0;
       text-transform: uppercase;
     }
 
-    &__date {
+    .content__date {
+      @include media(small) {
+        grid-row: 4;
+        padding: 1rem 1.35rem 0;
+      }
       appearance: none;
       color: $v3-color_gray-dark;
       font-family: $font_family-secondary-light;
       font-size: $font_size-small;
-      grid-column-start: 2;
-      grid-row-start: 2;
       padding: 1rem 0 0;
     }
 
-    &__title {
+    .content__title {
+      @include media(small) {
+        grid-row: 3;
+        padding: .5rem 1.35rem 0;
+      }
       color: $v3-color_green-medium;
       font-family: $font_family-primary;
       font-size: $font_size-xlarge;
-      grid-column-start: 2;
-      grid-row-start: 3;
       padding: .5rem 0 0;
     }
 
-    &__tags {
+    .content__tags {
+      @include media(small) {
+        grid-row: 5;
+        padding: .5rem 1.35rem 0;
+      }
       color: $color_bg-darkgrey;
       font-family: $font_family-primary;
       font-size: $font_size-small;
       font-style: italic;
-      grid-column-start: 2;
-      grid-row-start: 4;
       padding: .5rem 0;
     }
 
-    &__body {
+    .content__body {
+      @include media (small) {
+        grid-row: 6;
+        margin-bottom: 1rem;
+        min-height: unset;
+        padding: .5rem 1.35rem 1rem;
+      }
       color: $v3-color_gray-dark;
       font-size: $font_size-small;
-      grid-column-end: 3;
-      grid-column-start: 2;
-      grid-row-start: 5;
       line-height: 1.5rem;
-      margin-bottom: 5rem;
-      padding: .5rem 0;
+      min-height: 27.85rem;
+      padding: .5rem 0 1rem;
     }
 
-    &__image {
+    .content__image {
       @include media(small) {
-        display: block;
-        float: none;
+        float: unset;
+        grid-row: 1;
+        margin: 0;
+        max-height: 20rem;
+        max-width: unset;
+        padding: 0;
+        width: 100%;
       }
-
       float: right;
-      grid-column-start: 2;
-      grid-row-start: 5;
       height: auto;
-      margin: 0 0 .6rem .8rem;
-      padding: 0 0 1rem 1rem;
-      width: 40vw;
+      margin: 10.25rem 0 .6rem .8rem;
+      max-width: 30rem;
+      padding: 0 1.35rem 1rem 1rem;
     }
   }
 }

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -2,16 +2,16 @@
   <div class="announcement">
     <div class="v2-banner"></div><!-- top green bar -->
       <div class="content container">
-        <div class="content__title"><%= @announcement.title %></div>
+        <% if @announcement.image %>
+          <%= image_tag(@announcement.image.url, class: "content__image") %>
+        <% end %>
         <div class="content__content-type">NEWS</div>
+        <div class="content__title"><%= @announcement.title %></div>
         <% if @announcement.published_date %>
           <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
         <% end %>
         <div class="content__tags">Tags: <%= @tags %></div>
         <div class="content__body">
-        <% if @announcement.image %>
-          <%= image_tag(@announcement.image.url, class: "content__image") %>
-        <% end %>
           <%= strip_tags @announcement.body %>
         </div>
       </div>

--- a/vendor/extensions/reports/app/views/refinery/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/show.html.erb
@@ -2,14 +2,14 @@
   <div class="report">
     <div class="v2-banner"></div><!-- top green bar -->
       <div class="content container">
-        <div class="content__title"><%= @report.title %></div>
-        <div class="content__content-type">PUBLICATION</div>
-        <div class="content__date"><%= @report.date.strftime("%B %d, %Y") %></div>
-        <div class="content__tags">Tags: <%= @tags %></div>
-        <div class="content__body">
         <% if @report.image %>
           <%= image_tag(@report.image.url, class: "content__image ") %>
         <% end %>
+        <div class="content__content-type">PUBLICATION</div>
+        <div class="content__title"><%= @report.title %></div>
+        <div class="content__date"><%= @report.date.strftime("%B %d, %Y") %></div>
+        <div class="content__tags">Tags: <%= @tags %></div>
+        <div class="content__body">
           <%= strip_tags @report.body %>
         </div>
       </div>


### PR DESCRIPTION
Resolves #408 .

# Why is this change necessary?
In #388 we re-structured the show pages for Reports and Announcements, but the existing styling didn't quite work on smaller (<670px wide) screens.

# How does it address the issue?
Added a breakpoint for 670px in a few places for both pages so that margins would reduce, allotting more screen space for content.

# What side effects does it have?
It fails the following test:
```
rspec ./spec/requests/findout_filter_spec.rb:85 # Findout Filter API requests GET /find-out returns JSON data for a specific report
```
However, Brad is examining this test further in #410 and suspects that it is related to the announcements page now requiring an image.