### PR TITLE
Re-add banner styling plus new media queries

### DIFF
--- a/app/assets/stylesheets/refinery/find_out.scss
+++ b/app/assets/stylesheets/refinery/find_out.scss
@@ -20,6 +20,10 @@
   }
 
   .find-out__header {
+    @include media (large) {
+      background-position-x: center;
+      background-position-y: -1.5rem;
+    }
     @include media (medium) {
       min-height: 24rem;
       padding-top: 8.85rem;
@@ -29,7 +33,10 @@
       min-height: 15rem;
       padding-top: 4.85rem;
     }
-    background-image: image-url('group-2111.png');
+    background-image: image-url('376-find-out-banner.png');
+    background-position-x: -7.8rem;
+    background-position-y: -1rem;
+    background-size: cover;
     display: flex;
     justify-content: center;
     min-height: 29rem;


### PR DESCRIPTION
Resolves #376 .

# Why is this change necessary?
Somehow the initial fix for the Find Out banner got lost in a rebase; this commit adds it back in.

# How does it address the issue?
I found the code snippet I used previously and added it back in.

# What side effects does it have?
Because the filter text isn't in "true center" (as it was in the initial PR), I added a couple of media queries to keep the background centered relative to the text.