### PR TITLE
423: find out card text margins

### DIFF
--- a/app/assets/stylesheets/refinery/find_out.scss
+++ b/app/assets/stylesheets/refinery/find_out.scss
@@ -257,6 +257,7 @@
       font-family: $font_family-secondary;
       font-size: $font_size-small;
       letter-spacing: .2rem;
+      margin-top: 1rem;
       text-transform: uppercase;
     }
 
@@ -266,6 +267,7 @@
       cursor: pointer;
       font-family: $font_family-primary;
       font-size: $font_size-medium;
+      margin-top: .5rem;
       text-decoration: none;
     }
 
@@ -277,6 +279,7 @@
       color: $v3-color_gray-dark;
       font-family: $font_family-primary;
       font-size: $font_size-small;
+      margin-top: .5rem;
       text-decoration: italic;
     }
   }


### PR DESCRIPTION
Resolves #423 .

# Why is this change necessary?
The space between text sections in Find Out cards didn't properly match the XD document and was too close together.

# How does it address the issue?
- 1rem margin-top between image and content type
- .5rem margin-top between content type/title and title/tags

# What side effects does it have?
None
