### PR TITLE
Standardize tags styling

### DIFF
--- a/app/assets/stylesheets/refinery/find_out.scss
+++ b/app/assets/stylesheets/refinery/find_out.scss
@@ -280,7 +280,7 @@
       font-family: $font_family-primary;
       font-size: $font_size-small;
       margin-top: .5rem;
-      text-decoration: italic;
+      font-style: italic;
     }
   }
 

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -209,7 +209,7 @@ Report.prototype.reportCardHtml = function reportCardHtml() {
   const tags = this.tags.map(tag => {
     if (tag.tag_type === 'topic_area') {
       return (`
-      <span><em>${tag.title}</em></span>
+      <span>${tag.title}</span>
     `)
     }
   }).join('')
@@ -287,7 +287,7 @@ Event.prototype.eventCardHtml = function eventCardHtml() {
   const tags = this.tags.map(tag => {
     if (tag.tag_type === 'topic_area') {
       return (`
-      <span><em>${tag.title}</em></span>
+      <span>${tag.title}</span>
     `)
     }
   }).join('')
@@ -323,7 +323,7 @@ Announcement.prototype.announcementCardHtml = function announcementCardHtml() {
   const tags = this.tags.map(tag => {
     if (tag.tag_type === 'topic_area') {
       return (`
-      <span><em>${tag.title}</em></span>
+      <span>${tag.title}</span>
     `)
     }
   }).join('')

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -10,7 +10,7 @@
         <% if @announcement.published_date %>
           <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
         <% end %>
-        <div class="content__tags">Tags: <%= @tags %></div>
+        <div class="content__tags">tags: <%= @tags %></div>
         <div class="content__body">
           <%= strip_tags @announcement.body %>
         </div>

--- a/vendor/extensions/reports/app/views/refinery/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/show.html.erb
@@ -8,7 +8,7 @@
         <div class="content__content-type">PUBLICATION</div>
         <div class="content__title"><%= @report.title %></div>
         <div class="content__date"><%= @report.date.strftime("%B %d, %Y") %></div>
-        <div class="content__tags">Tags: <%= @tags %></div>
+        <div class="content__tags">tags: <%= @tags %></div>
         <div class="content__body">
           <%= strip_tags @report.body %>
         </div>


### PR DESCRIPTION
Resolves #422  .

# Why is this change necessary?
We were styling `content__tags` differently on the Find Out page cards versus on the announcement/report show pages.

# How does it address the issue?
- sets all instances to lowercase (tags versus Tags)
- Adds `font-style: italics` to `content__tags` instead of styling inline with `<em>`

# What side effects does it have?
None
