### PR TITLE
Resolve 427: Fix font sizes for homepage buttons

### DIFF
--- a/app/assets/stylesheets/components/styled-box.scss
+++ b/app/assets/stylesheets/components/styled-box.scss
@@ -66,7 +66,8 @@
   }
 
   &__title {
-    @include media(small) { width: initial; }
+    @include media(small) { width: inherit; }
+    @include media(x-small) { font-size: 1rem;}
     background: none;
     display: inline-block;
     font-family: $font_family-secondary;

--- a/app/assets/stylesheets/partials/_event_box.scss
+++ b/app/assets/stylesheets/partials/_event_box.scss
@@ -13,7 +13,7 @@
       justify-content: center;
     }
     @media (max-width: 670px) { font-size: $font_size-small; }
-    @media (max-width: 320px) { font-size: $font_size-xsmall;}
+    @media (max-width: 325px) { font-size: $font_size-xsmall;}
 
     color: $color_font-light;
     display: flex;
@@ -31,7 +31,7 @@
     }
   }
 
-  ul {
+  &__content {
     display: inline-block;
     margin-top: 1.5rem;
     @media (min-width: 1400px) {

--- a/app/views/partials/_event_box.html.erb
+++ b/app/views/partials/_event_box.html.erb
@@ -2,6 +2,7 @@
 
 <div class="event-box">
   <%= link_to "Join us for an event!", events_events_path, class: "event-box__header" %>
+  <div class="event-box__content">
   <% if events.size > 0 %>
     <ul>
       <% events.each do |event| %>
@@ -19,4 +20,5 @@
       No upcoming events at this time.
     </p>
   <% end %>
+  </div>
 </div>


### PR DESCRIPTION
Resolves #427  .

# Why is this change necessary?
In merging multiple mobile design-based tickets, we found that there were a couple of mobile breakpoints unaddressed on the homepage that left some mobile users unable to read the full content.

# How does it address the issue?
- A couple additional media queries added
- Event box content refactored into a div that receives media queries under the class `.event-box__content`

# What side effects does it have?
None