### PR TITLE
Hide find-out link

### DIFF
--- a/app/views/refinery/_menu.html.erb
+++ b/app/views/refinery/_menu.html.erb
@@ -11,3 +11,12 @@
     %>
   </div>
 <% end %>
+
+<script>
+  $(function(){
+    // $('ul.nav').append("<li><a href='/find-out'>Find Out</a></li>")
+    $('ul.nav').append("<li><a href='/stories'>Voices From the Region</a></li>")
+    $('ul.nav').append("<li><a href='/process-details'>Process Details</a></li>")
+    $('ul.nav').append("<li><a href='/goals'>Goals</a></li>")
+  })
+</script>

--- a/app/views/refinery/_site_bar.html.erb
+++ b/app/views/refinery/_site_bar.html.erb
@@ -23,12 +23,3 @@
     </div>
   </div>
 <% end %>
-
-<script>
-  $(function(){
-    $('ul.nav').append("<li><a href='/find-out'>Find Out</a></li>")
-    $('ul.nav').append("<li><a href='/stories'>Voices From the Region</a></li>")
-    $('ul.nav').append("<li><a href='/process-details'>Process Details</a></li>")
-    $('ul.nav').append("<li><a href='/goals'>Goals</a></li>")
-  })
-</script>


### PR DESCRIPTION
* Move menu code to menu partial
* Hide find-out link

# Why is this change necessary?
We need to publish the completed site before we can upload content. 
We don't want to expose the `/find-out` link until after the content is up.
The code for the menu should be in the menu partial.

# How does it address the issue?
This change allows the current site to be published to staging, without exposing the find-out page until content can be uploaded. 
This change also moves the custom menu code to the menu partial, a more appropriate place than the previous location in `_site_bar_menu` partial.

# What side effects does it have?
In this version of the code, the `/find-out` link will be commented out in the menu. 
It will need to be edited in a future PR after content is uploaded.
