### PR TITLE
Create migration to delete nil taggings

### DIFF
--- a/db/migrate/20190905182535_delete_nil_taggings.rb
+++ b/db/migrate/20190905182535_delete_nil_taggings.rb
@@ -1,0 +1,9 @@
+class DeleteNilTaggings < ActiveRecord::Migration[5.2]
+  def change
+    Refinery::Taggings::Tagging.all.each do |tagging|
+      if !tagging.valid?
+        tagging.delete
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_31_153846) do
+ActiveRecord::Schema.define(version: 2019_09_05_182535) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
Resolves issue of rogue taggings

# Why is this change necessary?
Rogue taggings refer to deleted objects and cause hubadmin fail

# How does it address the issue?
This change finds all nil taggings and deletes them.

# What side effects does it have?
This runs one time via this migration. If needed, it can be put into a rake task in the future.
