### PR TITLE
Remove local plans TBD, update contact email address

### DIFF
--- a/app/views/refinery/pages/process_details.html.erb
+++ b/app/views/refinery/pages/process_details.html.erb
@@ -23,7 +23,7 @@
       <h1 class="process-details__title">Process Details</h1>
       <h2 class="process-details__subtitle">How We'll Shape the Region Together</h2>
       <p class="process-details__text">MetroCommon 2050 is a two-year undertaking that involves multiple phases, topics, and ideas; scores of planners; dozens of external advisors; and hundreds of state and local officials. Most important, it involves thousands of people from all over Metro Boston. It’s a complicated project, but running it smoothly is not enough – the entire point is the result. We must end up with an actionable plan, and one that makes change for the better.</p>
-      <p class="process-details__text">On this page, you’ll find information about the process behind MetroCommon. Timelines, advisory committees, and more. It’s the structure that undergirds the process. Keep checking back: it’s here we’re telling the story of “the how” of MetroCommon. Remember, if you have questions or comments, or if you’d like to get involved, <a href = "mailto: communications@mapc.org">please let us know.</a> It will take many of us who live, work, and play in the region to create the future we all want. Join us!</p>
+      <p class="process-details__text">On this page, you’ll find information about the process behind MetroCommon. Timelines, advisory committees, and more. It’s the structure that undergirds the process. Keep checking back: it’s here we’re telling the story of “the how” of MetroCommon. Remember, if you have questions or comments, or if you’d like to get involved, <a href = "mailto: MetroCommon2050@mapc.org">please let us know.</a> It will take many of us who live, work, and play in the region to create the future we all want. Join us!</p>
     </div>
     <div class="about-the-plan">
       <h1 class="about-the-plan__title">About The Plan</h1>
@@ -36,7 +36,7 @@
       <div class="external-advisors__text">
         <p>From the start, MAPC has had two overriding goals for MetroCommon 2050. First, that the plan, when completed, would be more than an artifact. Instead of just collecting dust, it would be used – turned into policy. And second, that MetroCommon would not only be implemented, but that in the end, it would be worth implementing.</p>
         <p>We’ve always known we couldn’t do this alone. We would need a large, diverse, committed group of stakeholders to lend us their opinions, impressions, and connections. Experts in policy, planning, analysis, outreach, and other technical matters; and experts in our communities and the lived realities of the kinds of topics the plan would discuss.</p>
-        <p>One of the structures through which we have been fortunate enough to tap such expertise is our external advisory groups. We are very thankful for the time and dedication our external advisors have devoted to this project. If you’d like to get involved, <a href = "mailto: communications@mapc.org">please contact us.</a> Let’s plan the region together!</p>
+        <p>One of the structures through which we have been fortunate enough to tap such expertise is our external advisory groups. We are very thankful for the time and dedication our external advisors have devoted to this project. If you’d like to get involved, <a href = "mailto: MetroCommon2050@mapc.org">please contact us.</a> Let’s plan the region together!</p>
       </div>
       <div class="cards">
         <div class="card">
@@ -71,35 +71,28 @@
   <div class="process-documents">
     <div class="container">
       <h1 class="process-documents__title">Process Documents</h1>
-        <div class="cards">
-          <div class="card">
-            <div class="card__download"><%= link_to image_tag('download.svg'), 'https://metrocommon.mapc.org/system/refinery/resources/W1siZiIsIjIwMTkvMDkvMDQvNHI0bTAycnhhYl9NQ19WYWx1ZXN2MDdEcmFmdF8yMDE5XzAxXzMwLnBkZiJdXQ/MC%20Valuesv07Draft_2019-01-30.pdf' %></div>
-            <div class="card__body">
-              <div class="card__title">MetroCommon Values</div>
-              <div class="card__subtitle">Values and Commitments that Guide MAPC and MetroCommon</div>
-            </div>
+      <div class="cards">
+        <div class="card">
+          <div class="card__download"><%= link_to image_tag('download.svg'), 'https://metrocommon.mapc.org/system/refinery/resources/W1siZiIsIjIwMTkvMDkvMDQvNHI0bTAycnhhYl9NQ19WYWx1ZXN2MDdEcmFmdF8yMDE5XzAxXzMwLnBkZiJdXQ/MC%20Valuesv07Draft_2019-01-30.pdf' %></div>
+          <div class="card__body">
+            <div class="card__title">MetroCommon Values</div>
+            <div class="card__subtitle">Values and Commitments that Guide MAPC and MetroCommon</div>
           </div>
-          <div class="card">
-            <div class="card__download"><%= link_to image_tag('download.svg'), 'https://metrocommon.mapc.org/system/refinery/resources/W1siZiIsIjIwMTkvMDIvMDUvOHFqNnNjMTA1bl8xN19NZXRyb0NvbW1vbl9Qcm9jZXNzX0Rlc2lnbl8yMDE4LnBkZiJdXQ/17%20MetroCommon%20Process%20Design%202018.pdf' %></div>
-            <div class="card__body">
-              <div class="card__title">Regional Plan Process Design</div>
-              <div class="card__subtitle">Roadmap for MetroCommon Planning Process</div>
-            </div>
+        </div>
+        <div class="card">
+          <div class="card__download"><%= link_to image_tag('download.svg'), 'https://metrocommon.mapc.org/system/refinery/resources/W1siZiIsIjIwMTkvMDIvMDUvOHFqNnNjMTA1bl8xN19NZXRyb0NvbW1vbl9Qcm9jZXNzX0Rlc2lnbl8yMDE4LnBkZiJdXQ/17%20MetroCommon%20Process%20Design%202018.pdf' %></div>
+          <div class="card__body">
+            <div class="card__title">Regional Plan Process Design</div>
+            <div class="card__subtitle">Roadmap for MetroCommon Planning Process</div>
           </div>
-          <div class="card">
-            <div class="card__download"><%= link_to image_tag('download.svg'), 'https://github.com/MAPC/digitalhub/files/3762891/RPU_ResearchAgenda_Projects_Approved_20181219.docx' %></div>
-            <div class="card__body">
-              <div class="card__title">Research Agenda</div>
-              <div class="card__subtitle">Initial List of MetroCommon Research Projects</div>
-            </div>
+        </div>
+        <div class="card">
+          <div class="card__download"><%= link_to image_tag('download.svg'), 'https://github.com/MAPC/digitalhub/files/3762891/RPU_ResearchAgenda_Projects_Approved_20181219.docx' %></div>
+          <div class="card__body">
+            <div class="card__title">Research Agenda</div>
+            <div class="card__subtitle">Initial List of MetroCommon Research Projects</div>
           </div>
-          <div class="card">
-            <div class="card__download"><%= link_to image_tag('download.svg'), '#' %></div>
-            <div class="card__body">
-              <div class="card__title">Local Plans Memo</div>
-              <div class="card__subtitle">TBD</div>
-            </div>
-          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#38 Why is this change necessary?
* Client requests new contact us email address
* Client requests, remove "Local Plans Memo"

# How does it address the issue?
* Update contact us email address to: "MetroCommon2050@mapc.org"
* Remove "Local Plans Memo" from download docs section

# What side effects does it have?
None