### PR TITLE
Add scenario planning process document

### DIFF
--- a/app/views/refinery/pages/process_details.html.erb
+++ b/app/views/refinery/pages/process_details.html.erb
@@ -93,6 +93,13 @@
             <div class="card__subtitle">Initial List of MetroCommon Research Projects</div>
           </div>
         </div>
+        <div class="card">
+          <div class="card__download"><%= link_to image_tag('download.svg'), 'https://metrocommon.mapc.org/system/refinery/resources/W1siZiIsIjIwMTkvMTIvMDIvODQ3ZmY3bHA4ZF9NZXRyb0NvbW1vbl8yMDUwX1NjZW5hcmlvX1BsYW5uaW5nX1Byb2Nlc3NfRG9jdW1lbnRfd2ViLnBkZiJdXQ/MetroCommon%202050%20Scenario%20Planning%20Process%20Document%20web.pdf' %></div>
+          <div class="card__body">
+            <div class="card__title">MetroCommon 2050</div>
+            <div class="card__subtitle">Scenario Planning Process Document</div>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#Why is this change necessary?
Kit Un requested additional document on the Process Details page.

# How does it address the issue?
This code adds a download box in Process Documents at the bottom of the page.

# What side effects does it have?
None, the document can be removed/renamed, etc from within HubAdmin interface /files section.