### PR TITLE
Add file to External Advisors; update font and font color

### DIFF
--- a/app/assets/stylesheets/refinery/process_details.scss
+++ b/app/assets/stylesheets/refinery/process_details.scss
@@ -44,8 +44,7 @@
     }
 
     &__text {
-      color: $v3-color_gray-dark;
-      font-family: $font_family-secondary-light;
+      font-family: $font_family-primary;
     }
   }
 
@@ -123,13 +122,12 @@
     }
 
     &__text {
-      color: $v3-color_gray-dark;
-      font-family: $font_family-secondary-light;
+      font-family: $font_family-primary;
       margin-bottom: 4rem;
     }
 
     .cards {
-      width: 77vw;
+      width: 55vw;
     }
 
     .card {

--- a/app/views/refinery/pages/process_details.html.erb
+++ b/app/views/refinery/pages/process_details.html.erb
@@ -60,6 +60,13 @@
             <div class="card__subtitle"></div>
           </div>
         </div>
+        <div class="card">
+          <div class="card__download dark-border"><%= link_to image_tag('download.svg'), 'https://metrocommon.mapc.org/system/refinery/resources/W1siZiIsIjIwMjAvMDEvMDIvODFkamppcW1uMV9TUF9BZHZpc29yeUNvbW1pdHRlZXMucGRmIl1d/SP_AdvisoryCommittees.pdf', alt: 'Scenario Planning Advisory Committee pdf' %></div>
+          <div class="card__body">
+            <div class="card__title">Scenario Planning Advisory Committee</div>
+            <div class="card__subtitle"></div>
+          </div>
+        </div>
       </div>
     </div>
     <div class="process-timeline">


### PR DESCRIPTION
#103 Why is this change necessary?
Comms team requested additional file to be added.
Designer asked for update of font and font color to be consistent with site.

# How does it address the issue?
* Added file to hubadmin
* Added download box to External Advisors section
* Remove font-color from sections Process Details and External Advisors, to allow p tag to inherit correct font "Swift"

# What side effects does it have?
The link opens the file in the browser. 
I was not able to get it to be an automatic download.

