### PR TITLE
Fix Find Out Order and Upcoming Events

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,11 +9,7 @@ module.exports = {
     "jquery": true
   },
   "rules": {
-    "no-use-before-define": "off",
     "arrow-body-style": "off",
     "arrow-parens": "off",
-    "semi": "off",
-    "max-len": "off",
-    "comma-dangle": "off"
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -11,5 +11,11 @@ module.exports = {
   "rules": {
     "arrow-body-style": "off",
     "arrow-parens": "off",
+    "max-len": ['error', {
+      "ignoreStrings": true,
+      "tabWidth": 2,
+      "ignoreTemplateLiterals": true,
+      "ignoreUrls": true
+    }]
   }
 };

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -81,7 +81,10 @@ const fetchTaggings = (dropdownsObject) => {
 
     const nextThreeEvents = () => {
       if (dropdownsObject.content_type === 'events') {
-        loadNextThreeEvents(response.next_three_events, $('.results'));
+        const nextThree = response.next_three_events.map(event => {
+          return new Event(event);
+        });
+        $('.results').prepend(Event.nextThreeHtml(nextThree));
       }
     };
 
@@ -147,14 +150,6 @@ const loadInitialCards = (taggings, resultsDiv, dropdownsObject) => {
       $('#load-more').hide();
     }
   }
-};
-
-const loadNextThreeEvents = (events, resultsDiv) => {
-  const nextThree = events.map(event => {
-    return new Event(event);
-  });
-  const nextThreeEventsHtml = Event.nextThree(nextThree);
-  resultsDiv.prepend(nextThreeEventsHtml);
 };
 
 const loadRemainingCards = (taggings, resultsDiv) => {
@@ -225,7 +220,7 @@ class Event {
     this.zipcode = eventResponse.data.attributes.zipcode;
   }
 
-  static nextThree(events) {
+  static nextThreeHtml(events) {
     const receiveUpdatesUrl = $('.next-three-events__receive-updates-url')[0].innerHTML;
     const noEventsMessageHtml = (`
       <div>

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -162,7 +162,10 @@ const showLoadMoreButton = (remainingCards, resultsDiv) => {
   $('#load-more')
     .show()
     .unbind('click')
-    .bind('click', () => { loadRemainingCards(remainingCards, resultsDiv); });
+    .bind('click', (event) => {
+      event.preventDefault();
+      loadRemainingCards(remainingCards, resultsDiv);
+    });
 };
 
 class Report {

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -93,7 +93,8 @@ const fetchTaggings = (dropdownsObject) => {
       $('.results').empty()
         .removeClass('results--cards-high')
         .addClass('results--cards-high');
-      $('.find-out__header').removeClass('find-out__header--large')
+      $('.find-out__header')
+        .removeClass('find-out__header--large')
         .addClass('find-out__header--large');
     };
 

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -270,12 +270,14 @@ Event.prototype.eventCardHtml = function eventCardHtml() {
     }
   }).join('');
 
+  const eventType = new Date(this.end) > new Date()  ? 'UPCOMING EVENT' : 'PAST EVENT';
+
   return (`
     <div class="card" data-sortdate="${Date.parse(this.start)}">
       <a href="/events/${this.id}">
         <img class="card__image" src=${this.image_url} />
       </a>
-      <div class="card__content-type">EVENT</div>
+      <div class="card__content-type">${eventType}</div>
       <div class="card__title">
         <a class="card__link" href="/events/${this.id}">${this.title}</a>
         <div class="card__tags">tags: ${tags}</div>

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -1,81 +1,72 @@
 $(() => {
   const allTaggings = {
     content_type: 'everything',
-    topic_area: 'all topic areas'
-  }
-  fetchTaggings(allTaggings)
-  loadDropdowns()
-  $('title')[0].text = 'MetroCommon 2050'
-})
+    topic_area: 'all topic areas',
+  };
+  fetchTaggings(allTaggings);
+  loadDropdowns();
+  $('title')[0].text = 'MetroCommon 2050';
+});
 
 function loadDropdowns() {
   $.get({
     url: '/tags.json',
     dataType: 'json',
   }).done((response) => {
-    const contentTypes = response.filter(tag => tag.data.attributes.tag_type === 'content_type')
-    const contentTypeSelectOptions = contentTypes.slice(0, 3).map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`).join('')
-    const contentTypeDropdown = (`<select class="content-type__select content-type__dropdown"><option id='all-content-types' value='everything' selected>everything</option>${contentTypeSelectOptions}</select>`)
-    document.getElementsByClassName('content-type')[0].innerHTML = `You're looking for ${contentTypeDropdown}`
+    const contentTypeSelectOptions = response.filter(tag => tag.data.attributes.tag_type === 'content_type')
+      .slice(0, 3)
+      .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`)
+      .join('');
+    const contentTypeDropdown = (`<select class="content-type__select content-type__dropdown"><option id='all-content-types' value='everything' selected>everything</option>${contentTypeSelectOptions}</select>`);
+    $('.content-type')[0].innerHTML = `You're looking for ${contentTypeDropdown}`;
 
-    const topicAreas = response.filter(tag => tag.data.attributes.tag_type === 'topic_area')
-    const topicAreaSelectOptions = topicAreas.map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`).join('')
-    const topicAreaDropdown = (`<select class="topic-area__select topic-area__dropdown"><option id='all-topic-areas' value='all topic areas' selected>all topic areas</option>${topicAreaSelectOptions}</select>`)
-    document.getElementsByClassName('topic-area')[0].innerHTML = `in ${topicAreaDropdown}`
-    onDropdownChange()
-    cueOverlay()
-  })
+    const topicAreaSelectOptions = response.filter(tag => tag.data.attributes.tag_type === 'topic_area')
+      .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`)
+      .join('');
+    const topicAreaDropdown = (`<select class="topic-area__select topic-area__dropdown"><option id='all-topic-areas' value='all topic areas' selected>all topic areas</option>${topicAreaSelectOptions}</select>`);
+    $('.topic-area')[0].innerHTML = `in ${topicAreaDropdown}`;
+
+    onDropdownChange();
+    cueOverlay();
+  });
 }
 
 const cueOverlay = () => {
-  $('.content-type__select').on('click', (event) => {
-    event.preventDefault()
-    $('div#find-out__overlay').addClass('find-out__overlay')
-  })
+  $('.content-type__select').on('click', () => {
+    $('#find-out__overlay').addClass('find-out__overlay');
+  });
 
-  $('.topic-area__select').on('click', (event) => {
-    event.preventDefault()
-    $('div#find-out__overlay').addClass('find-out__overlay')
-  })
-  onClickOverlay()
-}
+  $('.topic-area__select').on('click', () => {
+    $('#find-out__overlay').addClass('find-out__overlay');
+  });
+  onClickOverlay();
+};
 
 const openOverlay = () => {
-  $('span.current').on('click', (event) => {
-    event.preventDefault()
-    $('div#find-out__overlay').addClass('find-out__overlay')
-    onClickOverlay()
-  })
-}
+  $('.current').on('click', () => {
+    $('#find-out__overlay').addClass('find-out__overlay');
+    onClickOverlay();
+  });
+};
 
 const onClickOverlay = () => {
-  $('div#find-out__overlay').on('click', (event) => {
-    event.preventDefault()
-    closeOverlay()
-  })
-}
-
-const closeOverlay = () => {
-  $('div#find-out__overlay').removeClass('find-out__overlay')
-}
+  $('#find-out__overlay').on('click', () => {
+    $('#find-out__overlay').removeClass('find-out__overlay');
+  });
+};
 
 const onDropdownChange = () => {
-  $('select').niceSelect().on('change', (event) => {
-    openOverlay()
-    event.preventDefault()
-    const dropdownSelections = Array.from(document.getElementsByTagName('option')).filter(tag => tag.selected)
+  $('select').niceSelect().on('change', () => {
+    openOverlay();
+    const dropdownSelections = Array.from($('option')).filter(tag => tag.selected);
     const dropdownsObject = {
       content_type: dropdownSelections[0].innerText,
-      topic_area: dropdownSelections[1].innerText
-    }
-    fetchTaggings(dropdownsObject)
-    closeOverlay()
-  })
-}
-
-const loadTopicAreaNarrative = (title, body) => {
-  $('.narrative-text').text(body)
-}
+      topic_area: dropdownSelections[1].innerText,
+    };
+    fetchTaggings(dropdownsObject);
+    $('div#find-out__overlay').removeClass('find-out__overlay');
+  });
+};
 
 const fetchTaggings = (dropdownsObject) => {
   $.get({
@@ -83,125 +74,113 @@ const fetchTaggings = (dropdownsObject) => {
     dataType: 'json',
     data: dropdownsObject,
   }).done(response => {
-    const resultsDiv = $('.results')
-    const headerDiv = $('.find-out__header')
-
     const headerSmallCardsLow = () => {
-      headerDiv.removeClass('find-out__header--large')
-      resultsDiv.removeClass('results--cards-high')
-    }
-
-    const headerLargeCardsHigh = () => {
-      headerDiv.addClass('find-out__header--large')
-      resultsDiv.addClass('results--cards-high')
-    }
+      $('.find-out__header').removeClass('find-out__header--large');
+      $('.results').removeClass('results--cards-high');
+    };
 
     const nextThreeEvents = () => {
       if (dropdownsObject.content_type === 'events') {
-        loadNextThreeEvents(response.next_three_events, resultsDiv)
+        loadNextThreeEvents(response.next_three_events, $('.results'));
       }
-    }
+    };
 
     const resetDisplay = () => {
-      $('.narrative-text').empty()
-      resultsDiv.empty()
-      resultsDiv.removeClass('results--cards-high')
-      headerDiv.removeClass('find-out__header--large')
-      headerLargeCardsHigh()
-    }
+      $('.narrative-text').empty();
+      $('.results').empty()
+        .removeClass('results--cards-high')
+        .addClass('results--cards-high');
+      $('.find-out__header').removeClass('find-out__header--large')
+        .addClass('find-out__header--large');
+    };
 
-    resetDisplay()
-    loadTopicAreaNarrative(dropdownsObject.topic_area, response.topic_area_narrative)
+    resetDisplay();
+    $('.narrative-text').text(response.topic_area_narrative);
 
     if (dropdownsObject.topic_area === 'all topic areas' && dropdownsObject.content_type !== 'events') {
-      headerSmallCardsLow()
+      headerSmallCardsLow();
     } else if (response.taggings.length === 0) {
-      headerSmallCardsLow()
+      headerSmallCardsLow();
     } else if (dropdownsObject.content_type === 'events' && response.taggings.length > 0) {
-      nextThreeEvents()
+      nextThreeEvents();
     }
 
-    loadInitialCards(response.taggings, resultsDiv, dropdownsObject)
-    onClickOverlay()
-  })
-}
+    loadInitialCards(response.taggings, $('.results'), dropdownsObject);
+    onClickOverlay();
+  });
+};
 
 const createCards = (taggings, resultsDiv) => {
   taggings.forEach(tagging => {
     if (tagging.data.attributes.announcement_id) {
-      const announcement = new Announcement(tagging.data.attributes.tagged_item)
-      const announcementCard = announcement.announcementCardHtml()
-      resultsDiv.append(announcementCard)
+      resultsDiv.append(
+        new Announcement(tagging.data.attributes.tagged_item).announcementCardHtml(),
+      );
     } else if (tagging.data.attributes.report_id) {
-      const report = new Report(tagging.data.attributes.tagged_item)
-      const reportCard = report.reportCardHtml()
-      resultsDiv.append(reportCard)
+      resultsDiv.append(
+        new Report(tagging.data.attributes.tagged_item).reportCardHtml(),
+      );
     } else if (tagging.data.attributes.event_id) {
-      const event = new Event(tagging.data.attributes.tagged_item)
-      const eventCard = event.eventCardHtml()
-      resultsDiv.append(eventCard)
+      resultsDiv.append(
+        new Event(tagging.data.attributes.tagged_item).eventCardHtml(),
+      );
     }
-  })
-}
+  });
+};
 
 const loadInitialCards = (taggings, resultsDiv, dropdownsObject) => {
   if (taggings.length === 0) {
-    $('.results').html('<div class="message--none">There are currently no results for the selected filters.</div>')
-    hideLoadMoreButton()
+    $('.results').html('<div class="message--none">There are currently no results for the selected filters.</div>');
+    $('#load-more').hide();
   } else if (dropdownsObject.content_type === 'events') {
-    createCards(taggings.slice(0, 8), resultsDiv)
+    createCards(taggings.slice(0, 8), resultsDiv);
     if (taggings.length > 8) {
-      showLoadMoreButton(taggings.slice(8, taggings.length - 1), resultsDiv)
+      showLoadMoreButton(taggings.slice(8, taggings.length - 1), resultsDiv);
     } else {
-      hideLoadMoreButton()
+      $('#load-more').hide();
     }
   } else {
-    createCards(taggings.slice(0, 9), resultsDiv)
+    createCards(taggings.slice(0, 9), resultsDiv);
     if (taggings.length > 9) {
-      showLoadMoreButton(taggings.slice(9, taggings.length - 1), resultsDiv)
+      showLoadMoreButton(taggings.slice(9, taggings.length - 1), resultsDiv);
     } else {
-      hideLoadMoreButton()
+      $('#load-more').hide();
     }
   }
-}
+};
 
 const loadNextThreeEvents = (events, resultsDiv) => {
   const nextThree = events.map(event => {
-    return new Event(event)
-  })
-  const nextThreeEventsHtml = Event.nextThree(nextThree)
-  resultsDiv.prepend(nextThreeEventsHtml)
-}
+    return new Event(event);
+  });
+  const nextThreeEventsHtml = Event.nextThree(nextThree);
+  resultsDiv.prepend(nextThreeEventsHtml);
+};
 
 const loadRemainingCards = (taggings, resultsDiv) => {
-  createCards(taggings, resultsDiv)
-  hideLoadMoreButton()
-}
-
-const hideLoadMoreButton = () => {
-  $('#load-more').hide()
-}
+  createCards(taggings, resultsDiv);
+  $('#load-more').hide();
+};
 
 const showLoadMoreButton = (remainingCards, resultsDiv) => {
-  $('#load-more').show()
-  $('#load-more').unbind('click')
+  $('#load-more').show();
+  $('#load-more').unbind('click');
   $('#load-more').bind('click', (event) => {
-    event.preventDefault()
-    loadRemainingCards(remainingCards, resultsDiv)
-  })
-}
+    loadRemainingCards(remainingCards, resultsDiv);
+  });
+};
 
 // Report class
 class Report {
   constructor(reportResponse) {
-    this.title = reportResponse.data.attributes.title
-    this.tags = reportResponse.data.attributes.tags
-    this.id = reportResponse.data.id
-    this.title = reportResponse.data.attributes.title
-    this.link = reportResponse.data.attributes.link
-    this.image_url = reportResponse.included[0].attributes.url
-    this.position = reportResponse.data.attributes.position
-    this.date = reportResponse.data.attributes.date
+    this.title = reportResponse.data.attributes.title;
+    this.tags = reportResponse.data.attributes.tags;
+    this.id = reportResponse.data.id;
+    this.title = reportResponse.data.attributes.title;
+    this.link = reportResponse.data.attributes.link;
+    this.image_url = reportResponse.included[0].attributes.url;
+    this.position = reportResponse.data.attributes.position;
+    this.date = reportResponse.data.attributes.date;
   }
 }
 
@@ -210,9 +189,9 @@ Report.prototype.reportCardHtml = function reportCardHtml() {
     if (tag.tag_type === 'topic_area') {
       return (`
       <span>${tag.title}</span>
-    `)
+    `);
     }
-  }).join('')
+  }).join('');
 
   return (`
     <div class="card" data-sortdate="${Date.parse(this.date)}">
@@ -225,30 +204,29 @@ Report.prototype.reportCardHtml = function reportCardHtml() {
         <div class="card__tags">tags: ${tags}</div>
       </div>
     </div>
-  `)
-}
+  `);
+};
 
-// Event class
 class Event {
   constructor(eventResponse) {
-    this.id = eventResponse.data.id
-    this.type = eventResponse.data.type
-    this.tags = eventResponse.data.attributes.tags
-    this.title = eventResponse.data.attributes.title
-    this.event_type = eventResponse.data.attributes.event_type
-    this.image_url = eventResponse.included[0].attributes.url
-    this.description = eventResponse.data.attributes.description
-    this.registration_link = eventResponse.data.attributes.registration_link
-    this.start = eventResponse.data.attributes.start
-    this.end = eventResponse.data.attributes.end
-    this.address = eventResponse.data.attributes.address
-    this.city = eventResponse.data.attributes.city
-    this.state = eventResponse.data.attributes.state
-    this.zipcode = eventResponse.data.attributes.zipcode
+    this.id = eventResponse.data.id;
+    this.type = eventResponse.data.type;
+    this.tags = eventResponse.data.attributes.tags;
+    this.title = eventResponse.data.attributes.title;
+    this.event_type = eventResponse.data.attributes.event_type;
+    this.image_url = eventResponse.included[0].attributes.url;
+    this.description = eventResponse.data.attributes.description;
+    this.registration_link = eventResponse.data.attributes.registration_link;
+    this.start = eventResponse.data.attributes.start;
+    this.end = eventResponse.data.attributes.end;
+    this.address = eventResponse.data.attributes.address;
+    this.city = eventResponse.data.attributes.city;
+    this.state = eventResponse.data.attributes.state;
+    this.zipcode = eventResponse.data.attributes.zipcode;
   }
 
   static nextThree(events) {
-    const receiveUpdatesUrl = $('.next-three-events__receive-updates-url')[0].innerHTML
+    const receiveUpdatesUrl = $('.next-three-events__receive-updates-url')[0].innerHTML;
     const noEventsMessageHtml = (`
       <div>
         <div class="next-three-events__event--title">No upcoming events at this time.</div>
@@ -256,10 +234,10 @@ class Event {
         <a class="button" rel="noopener noreferrer" href="${receiveUpdatesUrl}" target="_blank">Receive Updates</a>
         </div>
       </div>
-      `)
+      `);
 
     const nextThreeEventsHtml = events.map(event => {
-      const eventDateAndHours = `${moment(event.start).format('MMM Do, h:mmA')} - ${moment(event.end).format('h:mmA')}`
+      const eventDateAndHours = `${moment(event.start).format('MMM Do, h:mmA')} - ${moment(event.end).format('h:mmA')}`;
       return (`
       <a href='/events/${event.id}' style='text-decoration: none'>
         <div class='next-three-events__event'>
@@ -267,8 +245,8 @@ class Event {
           <div class='next-three-events__content'>${eventDateAndHours} | ${event.city}</div>
         </div>
       </a>
-      `)
-    }).join('')
+      `);
+    }).join('');
 
     return (`
       <div class="card">
@@ -279,7 +257,7 @@ class Event {
           </div>
         </div>
       </div>
-    `)
+    `);
   }
 }
 
@@ -288,9 +266,9 @@ Event.prototype.eventCardHtml = function eventCardHtml() {
     if (tag.tag_type === 'topic_area') {
       return (`
       <span>${tag.title}</span>
-    `)
+    `);
     }
-  }).join('')
+  }).join('');
 
   return (`
     <div class="card" data-sortdate="${Date.parse(this.start)}">
@@ -303,19 +281,19 @@ Event.prototype.eventCardHtml = function eventCardHtml() {
         <div class="card__tags">tags: ${tags}</div>
       </div>
     </div>
-  `)
-}
+  `);
+};
 
 // Announcement class
 class Announcement {
   constructor(announcementResponse) {
-    this.id = announcementResponse.data.id
-    this.title = announcementResponse.data.attributes.title
-    this.body = announcementResponse.data.attributes.body
-    this.tags = announcementResponse.data.attributes.tags
-    this.link = announcementResponse.data.attributes.link
-    this.image_url = announcementResponse.included[0].attributes.url
-    this.published_date = announcementResponse.data.attributes.published_date
+    this.id = announcementResponse.data.id;
+    this.title = announcementResponse.data.attributes.title;
+    this.body = announcementResponse.data.attributes.body;
+    this.tags = announcementResponse.data.attributes.tags;
+    this.link = announcementResponse.data.attributes.link;
+    this.image_url = announcementResponse.included[0].attributes.url;
+    this.published_date = announcementResponse.data.attributes.published_date;
   }
 }
 
@@ -324,9 +302,9 @@ Announcement.prototype.announcementCardHtml = function announcementCardHtml() {
     if (tag.tag_type === 'topic_area') {
       return (`
       <span>${tag.title}</span>
-    `)
+    `);
     }
-  }).join('')
+  }).join('');
 
   return (`
     <div class="card" data-sortdate="${Date.parse(this.published_date)}">
@@ -339,5 +317,5 @@ Announcement.prototype.announcementCardHtml = function announcementCardHtml() {
         <div class="card__tags">tags: ${tags}</div>
       </div>
     </div>
-  `)
-}
+  `);
+};

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -64,7 +64,7 @@ const onDropdownChange = () => {
       topic_area: dropdownSelections[1].innerText,
     };
     fetchTaggings(dropdownsObject);
-    $('div#find-out__overlay').removeClass('find-out__overlay');
+    $('#find-out__overlay').removeClass('find-out__overlay');
   });
 };
 
@@ -158,14 +158,12 @@ const loadRemainingCards = (taggings, resultsDiv) => {
 };
 
 const showLoadMoreButton = (remainingCards, resultsDiv) => {
-  $('#load-more').show();
-  $('#load-more').unbind('click');
-  $('#load-more').bind('click', (event) => {
-    loadRemainingCards(remainingCards, resultsDiv);
-  });
+  $('#load-more')
+    .show()
+    .unbind('click')
+    .bind('click', () => { loadRemainingCards(remainingCards, resultsDiv); });
 };
 
-// Report class
 class Report {
   constructor(reportResponse) {
     this.title = reportResponse.data.attributes.title;
@@ -281,7 +279,6 @@ Event.prototype.eventCardHtml = function eventCardHtml() {
   `);
 };
 
-// Announcement class
 class Announcement {
   constructor(announcementResponse) {
     this.id = announcementResponse.data.id;

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -142,7 +142,7 @@ const loadInitialCards = (taggings, resultsDiv, dropdownsObject) => {
   } else {
     createCards(taggings.slice(0, 9), resultsDiv);
     if (taggings.length > 9) {
-      showLoadMoreButton(taggings.slice(9, taggings.length - 1), resultsDiv);
+      showLoadMoreButton(taggings.slice(9, taggings.length), resultsDiv);
     } else {
       $('#load-more').hide();
     }

--- a/vendor/extensions/taggings/app/controllers/refinery/taggings/taggings_controller.rb
+++ b/vendor/extensions/taggings/app/controllers/refinery/taggings/taggings_controller.rb
@@ -8,9 +8,10 @@ module Refinery
       def index
         filters = [params[:content_type] || "everything", params[:topic_area] || "all topic areas"]
         topic_area_narrative = Refinery::Tags::Tag.all.find_by(title: filters[1]).narrative if filters[1] != "all topic areas"
-        filtered_taggings = Refinery::Taggings::Tagging.filter_taggings(filters)
-        filtered_taggings_sorted = filtered_taggings.sort { |a, b| b.sort_date <=> a.sort_date }.reverse
-        filtered_taggings_json = filtered_taggings_sorted.map {|t| TaggingSerializer.new(t).serializable_hash }
+        filtered_taggings_json = Refinery::Taggings::Tagging.filter_taggings(filters)
+          .sort { |a, b| b.sort_date <=> a.sort_date }
+          .reverse
+          .map {|t| TaggingSerializer.new(t).serializable_hash }
 
         respond_to do |f|
           f.html { present(@page) }

--- a/vendor/extensions/taggings/app/controllers/refinery/taggings/taggings_controller.rb
+++ b/vendor/extensions/taggings/app/controllers/refinery/taggings/taggings_controller.rb
@@ -10,7 +10,6 @@ module Refinery
         topic_area_narrative = Refinery::Tags::Tag.all.find_by(title: filters[1]).narrative if filters[1] != "all topic areas"
         filtered_taggings_json = Refinery::Taggings::Tagging.filter_taggings(filters)
           .sort { |a, b| b.sort_date <=> a.sort_date }
-          .reverse
           .map {|t| TaggingSerializer.new(t).serializable_hash }
 
         respond_to do |f|


### PR DESCRIPTION
# Why is this change necessary?
We want to display events and publications such that the most recent ones are first. We also want to distinguish between past and future events.

# How does it address the issue?
It updates the controller and JavaScript to do this.

# What side effects does it have?
We also do some refactoring and a minor bug fix, so hopefully none. However
* If you have ten objects and clicked load more nothing would happen, it turns out this was an off by one condition. A commit in this PR fixes that.