### PR TITLE
Mjz/469 report social cards

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,15 +3,15 @@
 <%= render "/refinery/html_tag" %>
   <% site_bar = render('/refinery/site_bar', :head => true) -%>
   <head>
-    <meta property="og:title" content="MetroCommon 2050" />
-    <meta property="og:type" content="website" />
-    <meta property="og:image" content="<%= image_url("mapc-social-sharing-image.png") %>" />
-    <meta property="og:description" content="Greater Boston’s next regional plan. Led by the Metropolitan Area Planning Council (MAPC)." />
-
-    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-nice-select/1.1.0/js/jquery.nice-select.js"></script>
-
     <%= render "/refinery/head" %>
+    <% if content_for?(:head) %>
+      <%= yield :head %>
+    <% else %>
+      <meta property="og:title" content="MetroCommon 2050" />
+      <meta property="og:type" content="website" />
+      <meta property="og:image" content="<%= image_url("mapc-social-sharing-image.png") %>" />
+      <meta property="og:description" content="Greater Boston’s next regional plan. Led by the Metropolitan Area Planning Council (MAPC)." />
+    <% end %>
     <%= render "/refinery/javascripts" %>
     <%= javascript_pack_tag 'application' %>
     <%= javascript_pack_tag 'polyfill' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,15 +11,6 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-nice-select/1.1.0/js/jquery.nice-select.js"></script>
 
-    <% if Rails.env.production? %>
-      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-5547782-36"></script>
-      <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'UA-5547782-36');
-      </script>
-    <% end %>
     <%= render "/refinery/head" %>
     <%= render "/refinery/javascripts" %>
     <%= javascript_pack_tag 'application' %>

--- a/app/views/refinery/_menu.html.erb
+++ b/app/views/refinery/_menu.html.erb
@@ -11,12 +11,3 @@
     %>
   </div>
 <% end %>
-
-<script>
-  $(function(){
-    // $('ul.nav').append("<li><a href='/find-out'>Find Out</a></li>")
-    $('ul.nav').append("<li><a href='/stories'>Voices From the Region</a></li>")
-    $('ul.nav').append("<li><a href='/process-details'>Process Details</a></li>")
-    $('ul.nav').append("<li><a href='/goals'>Goals</a></li>")
-  })
-</script>

--- a/config/initializers/refinery/core.rb
+++ b/config/initializers/refinery/core.rb
@@ -18,7 +18,7 @@ Refinery::Core.configure do |config|
   # This activates Google Analytics tracking within your website. If this
   # config is left blank or set to UA-xxxxxx-x then no remote calls to
   # Google Analytics are made.
-  # config.google_analytics_page_code = "UA-xxxxxx-x"
+  config.google_analytics_page_code = "UA-5547782-36"
 
   # Enable/disable authenticity token on frontend
   # config.authenticity_token_on_frontend = false

--- a/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
@@ -1,3 +1,10 @@
+<% content_for :head do %>
+  <meta property="og:title" content="<%= @report.title %>" />
+  <meta property="og:type" content="article" />
+  <meta property="og:article:published_time" content="<%= @report.date.iso8601 %>"
+  <meta property="og:image" content="<%= @report.image.url %>" />
+<% end %>
+
 <div class="Report">
   <div class="report">
     <div class="v2-banner"></div><!-- top green bar -->

--- a/vendor/extensions/taggings/app/views/refinery/taggings/taggings/index.html.erb
+++ b/vendor/extensions/taggings/app/views/refinery/taggings/taggings/index.html.erb
@@ -1,6 +1,16 @@
 <% content_for :javascript_packs do %>
-<%= javascript_pack_tag 'find-out' %>
+  <%= javascript_pack_tag 'find-out' %>
 <% end %>
+
+<% content_for :head do %>
+  <meta property="og:title" content="MetroCommon 2050 - Find Out" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="<%= image_url("mapc-social-sharing-image.png") %>" />
+  <meta property="og:description" content="Find out about Greater Boston’s next regional plan. Led by the Metropolitan Area Planning Council (MAPC)." />
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-nice-select/1.1.0/js/jquery.nice-select.js"></script>
+<% end %>
+
 
 <div class="FindOut">
   <section class="v2-banner">


### PR DESCRIPTION
Resolves #469 .

# Why is this change necessary?
We want custom social card images.

# How does it address the issue?
By making dynamic open graph tags for the report page template.

# What side effects does it have?
jQuery was isolated into the find-out page which is the one page where it seemed to be used. It also removes the jQuery that was adding menu items, leaving that responsibility to the refinery admin. A brief attempt was made to refactor jquery-nice-select into a babel/ES6 `import` in find-out.js, but jquery-nice-select would not play nice with the import. Several attempts to define `jQuery from 'query'` were attempted and failed. 