### PR TITLE
Mjz/464 alignment of terms

### DIFF
--- a/vendor/extensions/announcements/config/locales/en.yml
+++ b/vendor/extensions/announcements/config/locales/en.yml
@@ -2,25 +2,25 @@ en:
   refinery:
     plugins:
       announcements:
-        title: Announcements
+        title: News
     announcements:
       admin:
         announcements:
           actions:
             create_new: Add New Announcement
-            reorder: Reorder Announcements
-            reorder_done: Done Reordering Announcements
+            reorder: Reorder News
+            reorder_done: Done Reordering News
           records:
-            title: Announcements
+            title: News
             sorry_no_results: Sorry! There are no results found.
-            no_items_yet: There are no Announcements yet. Click "Add New Announcement" to add your first announcement.
+            no_items_yet: There is no news yet. Click "Add New News" to add your first news.
           announcement:
-            view_live_html: View this announcement live <br/><em>(opens in a new window)</em>
-            edit: Edit this announcement
-            delete: Remove this announcement forever
+            view_live_html: View this news live <br/><em>(opens in a new window)</em>
+            edit: Edit this news
+            delete: Remove this news forever
       announcements:
         show:
-          other: Other Announcements
+          other: Other News
   activerecord:
     attributes:
       'refinery/announcements/announcement':

--- a/vendor/extensions/reports/config/locales/en.yml
+++ b/vendor/extensions/reports/config/locales/en.yml
@@ -2,25 +2,25 @@ en:
   refinery:
     plugins:
       reports:
-        title: Reports
+        title: Publications
     reports:
       admin:
         reports:
           actions:
             create_new: Add New Report
             reorder: Reorder Reports
-            reorder_done: Done Reordering Reports
+            reorder_done: Done Reordering Publications
           records:
-            title: Reports
+            title: Publications
             sorry_no_results: Sorry! There are no results found.
-            no_items_yet: There are no Reports yet. Click "Add New Report" to add your first report.
+            no_items_yet: There are no Reports yet. Click "Add New Publications" to add your first report.
           report:
-            view_live_html: View this report live <br/><em>(opens in a new window)</em>
-            edit: Edit this report
-            delete: Remove this report forever
+            view_live_html: View this publication live <br/><em>(opens in a new window)</em>
+            edit: Edit this publication
+            delete: Remove this publication forever
       reports:
         show:
-          other: Other Reports
+          other: Other Publications
   activerecord:
     attributes:
       'refinery/reports/report':


### PR DESCRIPTION
Resolves #464.

# Why is this change necessary?
To improve consistency between the terms being used in the reader/public interface and the admin interface.

# How does it address the issue?
By updating the i18n YAML files to refer to the new nouns for these items.

# What side effects does it have?
Hopefully none. The international translations are no longer going to be consistent, but we do not have any admin editors attempting to update the website in French or other languages so that effort seems like it would be wasted.