### PR TITLE
Removing 🐥📼

### DIFF
--- a/app/views/refinery/pages/goals.html.erb
+++ b/app/views/refinery/pages/goals.html.erb
@@ -2,7 +2,6 @@
   <section class="v2-banner">
     <div class="container"></div>
   </section>
-    <iframe></iframe>
     <%= render partial: 'refinery/goals' %>
   <div class="container"></div>
 </div>


### PR DESCRIPTION
A while back a developer faced challenges trying to insert an IFRAME into the goals page. The IFRAME would disappear. They discovered that adding a blank IFRAME before the real IFRAME would fix this issue. It seemed strange, but the IFRAME vampire remained elusive. Now that we have ended the IFRAME vampire’s reign, this piece of duct tape is no longer needed. Removing this fixes the random IFRAME that makes the goal page look weird after fixing our other IFRAME windows.
