### PR TITLE
Fix Broken og:image Property

### DIFF
--- a/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
@@ -1,7 +1,7 @@
 <% content_for :head do %>
   <meta property="og:title" content="<%= @report.title %>" />
   <meta property="og:type" content="article" />
-  <meta property="og:article:published_time" content="<%= @report.date.iso8601 %>"
+  <meta property="og:article:published_time" content="<%= @report.date.iso8601 %>">
   <meta property="og:image" content="<%= @report.image.url %>" />
 <% end %>
 


### PR DESCRIPTION
A closing “>” was missing from this one line and caused the og:image tag to disappear. This commit adds it in and resolves the missing “og:image” tag.
