### PR TITLE
Add breakpoints for Mapbox iframe

### DIFF
--- a/app/assets/stylesheets/components/_all.scss
+++ b/app/assets/stylesheets/components/_all.scss
@@ -1,3 +1,4 @@
 @import 'button';
 @import 'grid';
 @import 'styled-box';
+@import 'mapbox';

--- a/app/assets/stylesheets/components/mapbox.scss
+++ b/app/assets/stylesheets/components/mapbox.scss
@@ -1,0 +1,12 @@
+.map__container {
+  $mobile-legend-height: 150px;
+  @include media(small) {
+    height: 333px + $mobile-legend-height;
+    width: 400px;
+  }
+
+  @include media(x-small) {
+    height: 250px + $mobile-legend-height;
+    width: 300px;
+  }
+}


### PR DESCRIPTION
# Why is this change necessary?
Need breakpoints for Mapbox map on DigitalHub
# How does it address the issue?
Use media queries from DataCommon/Large-Units

# What side effects does it have?
Need to add `.map__container` class to the mapboxGL iframe in order to use breakpoints
