### PR TITLE
Update height of legend to add study area boundary

### DIFF
--- a/app/assets/stylesheets/components/mapbox.scss
+++ b/app/assets/stylesheets/components/mapbox.scss
@@ -1,5 +1,5 @@
 .map__container {
-  $mobile-legend-height: 150px;
+  $mobile-legend-height: 195px;
   @include media(small) {
     height: 333px + $mobile-legend-height;
     width: 400px;


### PR DESCRIPTION
# Why is this change necessary?
We needed to add an item to the map with study area boundary and thus needed to re-calculate the height of the legend.
# How does it address the issue?
The legend height variable is reset from 150px to 195px both here and on DataCommon so that both maps size appropriately.
# What side effects does it have?
None; the only change here is to update a variable that is used in the following media queries.