### PR TITLE
Hide Translation from Refinery UI

### DIFF
--- a/config/initializers/refinery/i18n.rb
+++ b/config/initializers/refinery/i18n.rb
@@ -4,8 +4,8 @@ Refinery::I18n.configure do |config|
   config.default_locale = :en
   config.current_locale = :en
   config.default_frontend_locale = :en
-  config.frontend_locales = [:en, :pt, :es, :zh, :fr]
-  config.locales = {:en=>"English", :pt=>"Português", :es=>"Español", :zh=>"简体中文", :fr=>"Français" }
+  # config.frontend_locales = [:en, :pt, :es, :zh, :fr]
+  # config.locales = {:en=>"English", :pt=>"Português", :es=>"Español", :zh=>"简体中文", :fr=>"Français" }
   # Fallback language configuration so titles always have something
   Mobility.configure do |config|
     config.default_options[:fallbacks] = { :'pt' => 'en', :'es' => 'en', :'zh' => 'en', :'fr' => 'en' }


### PR DESCRIPTION
Since we have now switched to using Microsoft Translation we no longer want to display the translation control panel to Refinery CMS admin panel users. This commit changes the configuration to hide the language options and have users input their text in English.
