### PR TITLE
Mjz/announcements link field

### DIFF
--- a/app/assets/stylesheets/refinery/admin/tags.scss
+++ b/app/assets/stylesheets/refinery/admin/tags.scss
@@ -1,5 +1,4 @@
 .tags {
-  background: #FFFFE0;
   border: .1rem solid #707070;
   border-radius: .3rem;
   margin: 1rem 0;
@@ -30,17 +29,18 @@
 }
 
 .tags__selector-topic {
-  background-color: #62bef2;
+  background-color: #e9e9e9;
   border-radius: .3rem;
   box-shadow: 1px 1px 1px black;
   display: inline-block;
-  margin-bottom: .1rem;
+  margin: .18rem;
   padding: .5rem;
   white-space: nowrap;
 }
 
 .tags__selector-topic:hover {
   color: #fff;
+  background-color: #25a9f4;
 }
 
 .field {
@@ -49,8 +49,13 @@
 
 .nothing_selected,
 .remove_picked_image {
-  background: #62bef2;
+  background: #e9e9e9;
   border-radius: .3rem;
   box-shadow: 1px 1px 1px black;
   padding: .5rem;
+
+  &:hover {
+    color: #fff;
+    background-color: #25a9f4;
+  }
 }

--- a/app/assets/stylesheets/refinery/admin/tags.scss
+++ b/app/assets/stylesheets/refinery/admin/tags.scss
@@ -1,8 +1,16 @@
 .tags {
-  background-color: #fcdedee7;
+  background: #FFFFE0;
   border: .1rem solid #707070;
   border-radius: .3rem;
+  margin: 1rem 0;
   padding: 1rem;
+
+  &__label {
+    display: inline-block;
+    font-weight: normal;
+    text-transform: capitalize;
+    margin: 0;
+  }
 }
 
 .tags__header-content {
@@ -18,21 +26,31 @@
 .tags__header-topic {
   color: #111436;
   font-weight: bold;
-  font-size: .9rem;
+  font-size: .8125rem;
 }
 
 .tags__selector-topic {
-  background-color: none;
-  border: .1rem solid #f0efe7;
+  background-color: #62bef2;
   border-radius: .3rem;
-  font-size: .9rem;
+  box-shadow: 1px 1px 1px black;
+  display: inline-block;
   margin-bottom: .1rem;
-  padding-right: 1rem;
-  text-align: center;
-  width: 7rem;
+  padding: .5rem;
+  white-space: nowrap;
 }
 
 .tags__selector-topic:hover {
-  background-color: #a4bbeb;
   color: #fff;
+}
+
+.field {
+  margin: 0 0 .5rem 0;
+}
+
+.nothing_selected,
+.remove_picked_image {
+  background: #62bef2;
+  border-radius: .3rem;
+  box-shadow: 1px 1px 1px black;
+  padding: .5rem;
 }

--- a/vendor/extensions/announcements/app/controllers/refinery/announcements/admin/announcements_controller.rb
+++ b/vendor/extensions/announcements/app/controllers/refinery/announcements/admin/announcements_controller.rb
@@ -6,34 +6,42 @@ module Refinery
         crudify :'refinery/announcements/announcement'
 
         def create
-          @announcement = Refinery::Announcements::Announcement.create(announcement_params)
-          if params[:tag]
-            tags = params[:tag][:tag_ids].each do |tid|
-              Refinery::Taggings::Tagging.create(announcement_id: @announcement.id, tag_id: tid.to_i)
+          @announcement = Refinery::Announcements::Announcement.new(announcement_params.except(:tags))
+          if announcement_params[:tags]
+            announcement_params[:tags].each do |tag_id|
+              @announcement.tags <<  Refinery::Tags::Tag.find(tag_id)
             end
           end
-          @announcement.save
-          redirect_to announcements_admin_announcements_path and return
+          if @announcement.save
+            flash[:notice] = "News was successfully created!"
+            redirect_to announcements_admin_announcements_path
+          else
+            render action: 'new'
+          end
         end
 
         def update
           @announcement = Refinery::Announcements::Announcement.find(params[:id])
-          @announcement.update(announcement_params)
-          if params[:tag]
-            @announcement.taggings.each {|t| t.delete}
-            tags = params[:tag][:tag_ids].each do |tid|
-              new_tagging = Refinery::Taggings::Tagging.create(announcement_id: @announcement.id, tag_id: tid.to_i)
+          @announcement.update(announcement_params.except(:tags))
+          if announcement_params[:tags]
+            @announcement.tags = [Refinery::Tags::Tag.find(9)]
+            announcement_params[:tags].each do |tag_id|
+              @announcement.tags <<  Refinery::Tags::Tag.find(tag_id)
             end
           end
-          @announcement.save
-          redirect_to announcements_admin_announcements_path and return
+          if @announcement.save
+            flash[:notice] = "News was successfully updated!"
+            redirect_to announcements_admin_announcements_path
+          else
+            render action: 'update'
+          end
         end
 
         private
 
         # Only allow a trusted parameter "white list" through.
         def announcement_params
-          params.require(:announcement).permit(:title, :body, :published_date, :image_id, :link, :tag, :image_credit)
+          params.require(:announcement).permit(:title, :body, :published_date, :image_id, :link, :image_credit, tags: [])
         end
       end
     end

--- a/vendor/extensions/announcements/app/models/refinery/announcements/announcement.rb
+++ b/vendor/extensions/announcements/app/models/refinery/announcements/announcement.rb
@@ -7,11 +7,12 @@ module Refinery
       extend Mobility
       translates :title, :body
 
-      validates :title, :presence => true, :uniqueness => true
-      validates :published_date, :presence => true
       belongs_to :image, :class_name => '::Refinery::Image'
       has_many :taggings, :class_name => '::Refinery::Taggings::Tagging', dependent: :destroy
       has_many :tags, :class_name => '::Refinery::Tags::Tag', through: :taggings
+      validates :title, :presence => true, :uniqueness => true
+      validates :published_date, :presence => true
+      validate :tags_length
 
       def self.tagged_with(title)
         Refinery::Tags::Tag.find_by_title!(title).announcements
@@ -35,6 +36,13 @@ module Refinery
       def tag_content_type
         self.tags.where(tag_type: "content_type")[0].title
       end
+
+      def tags_length
+        if tags.length < 2
+          errors.add(:missing_tags, "please select at least one tag")
+        end
+      end
+
     end
   end
 end

--- a/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
@@ -22,6 +22,11 @@
                 :object => "announcements/announcement" -%>
   </div>
 
+  <div class='field'>
+    <%= f.label :link -%>
+    <%= f.text_field :link, :class => 'widest' -%>
+  </div>
+
 <%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
   <div class="tags">
     <div class='tags__header-content'>
@@ -31,25 +36,26 @@
       <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
          <span class="tags__selector-content">
            <input type="checkbox"
-                  name="tag[tag_ids][]"
+                  name="announcement[tags][]"
                   id="tag_<%= tag.id %>"
                   value="<%= tag.id %>"
                   <%= 'checked' if tag.title == "news" %>
             >
-            <%= tag.title %>
+            <label for="tag_<%= tag.id %>">
+              <%= tag.title %>
+            </label>
         </span>
       <% end %>
     </div>
 
 
     <div class='tags__header-topic'>Required:</div>
-    <div class='field'>
     <div class='tags__header-topic'>Choose or upload an image</div>
-      <%= render '/refinery/admin/image_picker',
-        :f => f,
-        :field => :image_id,
-        :image => @announcement.image,
-        :toggle_image_display => false -%>
+    <%= render '/refinery/admin/image_picker',
+      :f => f,
+      :field => :image_id,
+      :image => @announcement.image,
+      :toggle_image_display => false -%>
     </div>
     <%= f.label :image_credit -%>
     <%= f.text_field :image_credit -%>
@@ -57,13 +63,17 @@
       <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
         <span class="tags__selector-topic">
           <input type="checkbox"
-                 name="tag[tag_ids][]"
+                 name="announcement[tags][]"
                  id="tag_<%= tag.id %>"
                  value="<%= tag.id %>"
                  <%= 'checked' if @announcement.tags.include?(tag) %>
                  class="tags__selector-selected"
             >
-            <%= tag.title %>
+            <label for="tag_<%= tag.id %>"
+                   class="tags__label"
+            >
+              <%= tag.title %>
+            </label>
         </span>
       <% end %>
     </div>
@@ -74,28 +84,4 @@
              delete_title: t('delete', scope: 'refinery.announcements.admin.announcements.announcement'),
              delete_confirmation: t('message', scope: 'refinery.admin.delete', title: @announcement.title),
              cancel_url: refinery.announcements_admin_announcements_path -%>
-<% end -%>
-
-<% content_for :javascripts do -%>
-  <script>
-    $(document).ready(function(){
-      page_options.init(false, '', '');
-      checkTopicAreas();
-    });
-
-    function checkTopicAreas (){
-      $('input#submit_button.wymupdate.button').hide()
-        $('.tags').css("background-color", "#fcdedee7")
-      const topicAreas = Array.from(document.getElementsByClassName('tags__selector-topic'))
-
-      topicAreas.forEach(topic => {
-        if(topic.firstChild.checked){
-          $('input#submit_button.wymupdate.button').show()
-          $('.tags').css("background-color", "#a4bbeb")
-        }
-      })
-      $('.tags__selector-topic').on('click', checkTopicAreas)
-    }
-  </script>
-
 <% end -%>

--- a/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
@@ -24,11 +24,20 @@
 
 <%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
   <div class="tags">
-    <div class='tags__header-content'>Content Type: ("news" by default, hidden from view)</div>
+    <div class='tags__header-content'>
+      Content Type: ("news" by default, hidden from view)
+    </div>
     <div>
       <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
-         <span class="tags__selector-content"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"
-         <%= 'checked' if tag.title == "news" %>><%= tag.title %></input></span>
+         <span class="tags__selector-content">
+           <input type="checkbox"
+                  name="tag[tag_ids][]"
+                  id="tag_<%= tag.id %>"
+                  value="<%= tag.id %>"
+                  <%= 'checked' if tag.title == "news" %>
+            >
+            <%= tag.title %>
+        </span>
       <% end %>
     </div>
 
@@ -46,8 +55,16 @@
     <%= f.text_field :image_credit -%>
     <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
       <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
-        <span class="tags__selector-topic"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"
-        <%= 'checked' if @announcement.tags.include?(tag) %> class="tags__selector-selected"><%= tag.title %></input></span>
+        <span class="tags__selector-topic">
+          <input type="checkbox"
+                 name="tag[tag_ids][]"
+                 id="tag_<%= tag.id %>"
+                 value="<%= tag.id %>"
+                 <%= 'checked' if @announcement.tags.include?(tag) %>
+                 class="tags__selector-selected"
+            >
+            <%= tag.title %>
+        </span>
       <% end %>
     </div>
   </div>

--- a/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
@@ -24,7 +24,7 @@
 
   <div class='field'>
     <%= f.label :link -%>
-    <%= f.text_field :link, :class => 'widest' -%>
+    <%= f.text_field :link, :class => 'widest', placeholder: '/reports/4' -%>
   </div>
 
 <%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
@@ -56,27 +56,25 @@
       :field => :image_id,
       :image => @announcement.image,
       :toggle_image_display => false -%>
-    </div>
     <%= f.label :image_credit -%>
     <%= f.text_field :image_credit -%>
     <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
-      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
-        <span class="tags__selector-topic">
-          <input type="checkbox"
-                 name="announcement[tags][]"
-                 id="tag_<%= tag.id %>"
-                 value="<%= tag.id %>"
-                 <%= 'checked' if @announcement.tags.include?(tag) %>
-                 class="tags__selector-selected"
-            >
-            <label for="tag_<%= tag.id %>"
-                   class="tags__label"
-            >
-              <%= tag.title %>
-            </label>
-        </span>
-      <% end %>
-    </div>
+    <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
+      <span class="tags__selector-topic">
+        <input type="checkbox"
+               name="announcement[tags][]"
+               id="tag_<%= tag.id %>"
+               value="<%= tag.id %>"
+               <%= 'checked' if @announcement.tags.include?(tag) %>
+               class="tags__selector-selected"
+          >
+          <label for="tag_<%= tag.id %>"
+                 class="tags__label"
+          >
+            <%= tag.title %>
+          </label>
+      </span>
+    <% end %>
   </div>
 
   <%= render '/refinery/admin/form_actions', f: f,

--- a/vendor/extensions/events/app/controllers/refinery/events/admin/events_controller.rb
+++ b/vendor/extensions/events/app/controllers/refinery/events/admin/events_controller.rb
@@ -6,34 +6,42 @@ module Refinery
         crudify :'refinery/events/event'
 
         def create
-          @event = Refinery::Events::Event.create(event_params)
-          if params[:tag]
-            tags = params[:tag][:tag_ids].each do |tid|
-              Refinery::Taggings::Tagging.create(event_id: @event.id, tag_id: tid.to_i)
+          @event = Refinery::Events::Event.new(event_params.except(:tags))
+          if event_params[:tags]
+            event_params[:tags].each do |tag_id|
+              @event.tags <<  Refinery::Tags::Tag.find(tag_id)
             end
           end
-          @event.save
-          redirect_to events_admin_events_path and return
+          if @event.save
+            flash[:notice] = "Event was successfully created!"
+            redirect_to events_admin_events_path
+          else
+            render action: 'new'
+          end
         end
 
         def update
           @event = Refinery::Events::Event.find(params[:id])
-          @event.update(event_params)
-          if params[:tag]
-            @event.taggings.each {|t| t.delete}
-            tags = params[:tag][:tag_ids].each do |tid|
-              new_tagging = Refinery::Taggings::Tagging.create(event_id: @event.id, tag_id: tid.to_i)
+          @event.update(event_params.except(:tags))
+          if event_params[:tags]
+            @event.tags = [Refinery::Tags::Tag.find(10)]
+            event_params[:tags].each do |tag_id|
+              @event.tags <<  Refinery::Tags::Tag.find(tag_id)
             end
           end
-          @event.save
-          redirect_to events_admin_events_path and return
+          if @event.save
+            flash[:notice] = "Event was successfully updated!"
+            redirect_to events_admin_events_path
+          else
+            render action: 'update'
+          end
         end
 
         private
 
         # Only allow a trusted parameter "white list" through.
         def event_params
-          params.require(:event).permit(:title, :description, :start, :end, :image_id, :event_type, :address, :city, :state, :zipcode, :registration_link, :accessibility_note, :translation_note, :browser_title, :meta_description, :location_name, :tag)
+          params.require(:event).permit(:title, :description, :start, :end, :image_id, :event_type, :address, :city, :state, :zipcode, :registration_link, :accessibility_note, :translation_note, :browser_title, :meta_description, :location_name, tags: [])
         end
       end
     end

--- a/vendor/extensions/events/app/models/refinery/events/event.rb
+++ b/vendor/extensions/events/app/models/refinery/events/event.rb
@@ -8,6 +8,7 @@ module Refinery
       translates :title, :description, :accessibility_note, :translation_note
       validates :title, :presence => true, :uniqueness => true
       validates :start, :presence => true
+      validate :tags_length
       belongs_to :image, :class_name => '::Refinery::Image'
 
       has_many :taggings, :class_name => '::Refinery::Taggings::Tagging', dependent: :destroy
@@ -39,6 +40,14 @@ module Refinery
       def self.next_three_events
         next_three = ::Refinery::Events::Event.where('start > ?', DateTime.now).order(start: :asc).first(3)
         next_three_json = next_three.map {|event| EventSerializer.new(event, { :include => [:image] }).serializable_hash }
+      end
+
+      private
+
+      def tags_length
+        if tags.length < 2
+          errors.add(:missing_tags, "please select at least one tag")
+        end
       end
     end
   end

--- a/vendor/extensions/events/app/views/refinery/events/admin/events/_form.html.erb
+++ b/vendor/extensions/events/app/views/refinery/events/admin/events/_form.html.erb
@@ -64,32 +64,54 @@
   </div>
   <%= render '/seo_meta/form', :form => f %>
 
-<%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
-  <div class="tags">
-    <div class='tags__header-content'>Content Type: ("events" by default, hidden from view)</div>
-    <div>
-      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
-        <span class="tags__selector-content"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>"
-          value="<%= tag.id %>" <%= 'checked' if @event.tags.include?(tag) %>><%= tag.title %></input></span>
-      <% end %>
-    </div>
+  <%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
+    <div class="tags">
+      <div class='tags__header-content'>
+        Content Type: ("publications" by default, hidden from view)
+      </div>
+      <div>
+        <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
+           <span class="tags__selector-content">
+             <input type="checkbox"
+                    name="event[tags][]"
+                    id="tag_<%= tag.id %>"
+                    value="<%= tag.id %>"
+                    <%= 'checked' if tag.title == "publications" %>
+              >
+              <label for="tag_<%= tag.id %>">
+                <%= tag.title %>
+              </label>
+          </span>
+        <% end %>
+      </div>
 
-    <div class='tags__header-topic'>Required:</div>
-    <div class='field'>
-    <div class='tags__header-topic'>Choose or upload an image</div>
+
+      <div class='tags__header-topic'>Required:</div>
+      <div class='tags__header-topic'>Choose or upload an image</div>
       <%= render '/refinery/admin/image_picker',
         :f => f,
         :field => :image_id,
         :image => @event.image,
         :toggle_image_display => false -%>
+      <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
+        <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
+          <span class="tags__selector-topic">
+            <input type="checkbox"
+                   name="event[tags][]"
+                   id="tag_<%= tag.id %>"
+                   value="<%= tag.id %>"
+                   <%= 'checked' if @event.tags.include?(tag) %>
+                   class="tags__selector-selected"
+              >
+              <label for="tag_<%= tag.id %>"
+                     class="tags__label"
+              >
+                <%= tag.title %>
+              </label>
+          </span>
+        <% end %>
+      </div>
     </div>
-    <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
-      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
-        <span class="tags__selector-topic"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"
-        <%= 'checked' if @event.tags.include?(tag) %> class="tags__selector-selected"><%= tag.title %></input></span>
-      <% end %>
-    </div>
-  </div>
 
   <%= render '/refinery/admin/form_actions', f: f,
              continue_editing: false,
@@ -102,22 +124,6 @@
   <script>
     $(document).ready(function(){
       page_options.init(false, '', '');
-      checkTopicAreas();
     });
-
-    function checkTopicAreas (){
-      $('input#submit_button.wymupdate.button').hide()
-        $('.tags').css("background-color", "#fcdedee7")
-      const topicAreas = Array.from(document.getElementsByClassName('tags__selector-topic'))
-
-      topicAreas.forEach(topic => {
-        if(topic.firstChild.checked){
-          $('input#submit_button.wymupdate.button').show()
-          $('.tags').css("background-color", "#a4bbeb")
-        }
-      })
-      $('.tags__selector-topic').on('click', checkTopicAreas)
-    }
   </script>
-
 <% end -%>

--- a/vendor/extensions/reports/app/models/refinery/reports/report.rb
+++ b/vendor/extensions/reports/app/models/refinery/reports/report.rb
@@ -5,6 +5,7 @@ module Refinery
 
       validates :title, :presence => true, :uniqueness => true
       validates :date, :presence => true
+      validate :tags_length
       belongs_to :image, :class_name => '::Refinery::Image'
       has_many :taggings, :class_name => '::Refinery::Taggings::Tagging', dependent: :destroy
       has_many :tags, :class_name => '::Refinery::Tags::Tag', through: :taggings
@@ -30,6 +31,14 @@ module Refinery
 
       def tag_content_type
         self.tags.where(tag_type: "content_type")[0].title
+      end
+
+      private
+
+      def tags_length
+        if tags.length < 2
+          errors.add(:missing_tags, "please select at least one tag")
+        end
       end
     end
   end

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
@@ -21,56 +21,54 @@
   </div>
 
   <%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
-    <div class="tags">
-      <div class='tags__header-content'>
-        Content Type: ("publications" by default, hidden from view)
-      </div>
-      <div>
-        <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
-           <span class="tags__selector-content">
-             <input type="checkbox"
-                    name="report[tags][]"
-                    id="tag_<%= tag.id %>"
-                    value="<%= tag.id %>"
-                    <%= 'checked' if tag.title == "publications" %>
-              >
-              <label for="tag_<%= tag.id %>">
-                <%= tag.title %>
-              </label>
-          </span>
-        <% end %>
-      </div>
+  <div class="tags">
+    <div class='tags__header-content'>
+      Content Type: ("publications" by default, hidden from view)
+    </div>
+    <div>
+      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
+         <span class="tags__selector-content">
+           <input type="checkbox"
+                  name="report[tags][]"
+                  id="tag_<%= tag.id %>"
+                  value="<%= tag.id %>"
+                  <%= 'checked' if tag.title == "publications" %>
+            >
+            <label for="tag_<%= tag.id %>">
+              <%= tag.title %>
+            </label>
+        </span>
+      <% end %>
+    </div>
 
 
-      <div class='tags__header-topic'>Required:</div>
-      <div class='tags__header-topic'>Choose or upload an image</div>
-      <%= render '/refinery/admin/image_picker',
-        :f => f,
-        :field => :image_id,
-        :image => @report.image,
-        :toggle_image_display => false -%>
-      <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
+    <div class='tags__header-topic'>Required:</div>
+    <div class='tags__header-topic'>Choose or upload an image</div>
+    <%= render '/refinery/admin/image_picker',
+      :f => f,
+      :field => :image_id,
+      :image => @report.image,
+      :toggle_image_display => false -%>
     <%= f.label :image_credit -%>
     <%= f.text_field :image_credit -%>
     <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
-        <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
-          <span class="tags__selector-topic">
-            <input type="checkbox"
-                   name="report[tags][]"
-                   id="tag_<%= tag.id %>"
-                   value="<%= tag.id %>"
-                   <%= 'checked' if @report.tags.include?(tag) %>
-                   class="tags__selector-selected"
-              >
-              <label for="tag_<%= tag.id %>"
-                     class="tags__label"
-              >
-                <%= tag.title %>
-              </label>
-          </span>
-        <% end %>
-      </div>
-    </div>
+    <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
+      <span class="tags__selector-topic">
+        <input type="checkbox"
+               name="report[tags][]"
+               id="tag_<%= tag.id %>"
+               value="<%= tag.id %>"
+               <%= 'checked' if @report.tags.include?(tag) %>
+               class="tags__selector-selected"
+          >
+          <label for="tag_<%= tag.id %>"
+                 class="tags__label"
+          >
+            <%= tag.title %>
+          </label>
+      </span>
+    <% end %>
+  </div>
 
   <%= render '/refinery/admin/form_actions', f: f,
              continue_editing: false,

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
@@ -20,62 +20,61 @@
     <%= f.date_select :date, required: true -%>
   </div>
 
-<%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
-  <div class="tags">
-    <div class='tags__header-content'>Content Type: ("publications" by default, hidden from view)</div>
-    <div>
-      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
-         <span class="tags__selector-content"><input type="radio" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"
-        <%= 'checked' if tag.title == "publications" %>><%= tag.title %></input></span>
-      <% end %>
-    </div>
+  <%# note: this section is not exposed to user, but retained in case of future need to apply multiple "content_type" tags to a taggable item %>
+    <div class="tags">
+      <div class='tags__header-content'>
+        Content Type: ("publications" by default, hidden from view)
+      </div>
+      <div>
+        <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "content_type" }.each do |tag| %>
+           <span class="tags__selector-content">
+             <input type="checkbox"
+                    name="report[tags][]"
+                    id="tag_<%= tag.id %>"
+                    value="<%= tag.id %>"
+                    <%= 'checked' if tag.title == "publications" %>
+              >
+              <label for="tag_<%= tag.id %>">
+                <%= tag.title %>
+              </label>
+          </span>
+        <% end %>
+      </div>
 
-    <div class='tags__header-topic'>Required:</div>
-    <div class='field'>
-    <div class='tags__header-topic'>Choose or upload an image</div>
+
+      <div class='tags__header-topic'>Required:</div>
+      <div class='tags__header-topic'>Choose or upload an image</div>
       <%= render '/refinery/admin/image_picker',
         :f => f,
         :field => :image_id,
         :image => @report.image,
         :toggle_image_display => false -%>
-    </div>
+      <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
     <%= f.label :image_credit -%>
     <%= f.text_field :image_credit -%>
     <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
-      <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
-        <span class="tags__selector-topic"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"
-        <%= 'checked' if @report.tags.include?(tag) %> class="tags__selector-selected"><%= tag.title %></input></span>
-      <% end %>
+        <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
+          <span class="tags__selector-topic">
+            <input type="checkbox"
+                   name="report[tags][]"
+                   id="tag_<%= tag.id %>"
+                   value="<%= tag.id %>"
+                   <%= 'checked' if @report.tags.include?(tag) %>
+                   class="tags__selector-selected"
+              >
+              <label for="tag_<%= tag.id %>"
+                     class="tags__label"
+              >
+                <%= tag.title %>
+              </label>
+          </span>
+        <% end %>
+      </div>
     </div>
-  </div>
 
   <%= render '/refinery/admin/form_actions', f: f,
              continue_editing: false,
              delete_title: t('delete', scope: 'refinery.reports.admin.reports.report'),
              delete_confirmation: t('message', scope: 'refinery.admin.delete', title: @report.title),
              cancel_url: refinery.reports_admin_reports_path -%>
-<% end -%>
-
-<% content_for :javascripts do -%>
-  <script>
-    $(document).ready(function(){
-      page_options.init(false, '', '');
-      checkTopicAreas();
-    });
-
-    function checkTopicAreas (){
-      $('input#submit_button.wymupdate.button').hide()
-        $('.tags').css("background-color", "#fcdedee7")
-      const topicAreas = Array.from(document.getElementsByClassName('tags__selector-topic'))
-
-      topicAreas.forEach(topic => {
-        if(topic.firstChild.checked){
-          $('input#submit_button.wymupdate.button').show()
-          $('.tags').css("background-color", "#a4bbeb")
-        }
-      })
-      $('.tags__selector-topic').on('click', checkTopicAreas)
-    }
-  </script>
-
 <% end -%>


### PR DESCRIPTION
# Why is this change necessary?
Until this change users had to request that an administrator update the link for a news or announcement item. 

# How does it address the issue?
By adding a field to the admin panel.

# What side effects does it have?
The change to the DOM caused the client side validation for tags to break. This lead to an interlude of refactoring this responsibility back into Rails. It may impact other controllers/extensions that now need to follow this pattern. If this does not break other extensions it should be ok to merge, but if it does then we need to go back and update the other extensions as well.