### PR TITLE
Att/484 capture filter state

### DIFF
--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -1,10 +1,10 @@
 $(() => {
-  const urlParams = window.location.pathname.split('/').slice(2).map(filter => filter.replace(/%20/g, " "));
+  const urlPathVariables = window.location.pathname.split('/').slice(2).map(filter => filter.replace(/%20/g, " "));
   let initialTaggings;
-  if (urlParams[0] && urlParams[1]) {
+  if (urlPathVariables[0] && urlPathVariables[1]) {
     initialTaggings = {
-      content_type: urlParams[0],
-      topic_area: urlParams[1],
+      content_type: urlPathVariables[0],
+      topic_area: urlPathVariables[1],
     };
   } else {
     initialTaggings = {
@@ -36,7 +36,7 @@ function loadDropdowns(initialTaggings) {
     const topicAreaDropdown = (`<select class="topic-area__select topic-area__dropdown">
       <option id='all-topic-areas' value='all topic areas' ${initialTaggings.topic_area === 'all-topic-areas' ? 'selected' : ''}>all topic areas</option>`
       + response.filter(tag => tag.data.attributes.tag_type === 'topic_area')
-        .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title" ${initialTaggings.topic_area === tag.data.attributes.title ? 'selected' : ''}>
+        .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title}  class="find-out__tag-title" ${initialTaggings.topic_area === tag.data.attributes.title ? 'selected' : ''}>
           ${tag.data.attributes.title}
         </option>`)
         .join('')
@@ -76,10 +76,11 @@ const onDropdownChange = () => {
     openOverlay();
     const dropdownSelections = Array.from($('option')).filter(tag => tag.selected);
     const dropdownsObject = {
-      content_type: dropdownSelections[0].innerText,
-      topic_area: dropdownSelections[1].innerText,
+      content_type: dropdownSelections[0].text,
+      topic_area: dropdownSelections[1].text,
     };
     fetchTaggings(dropdownsObject);
+    history.pushState(null, '', `/find-out/${dropdownsObject.content_type}/${dropdownsObject.topic_area}`)
     $('#find-out__overlay').removeClass('find-out__overlay');
   });
 };
@@ -88,7 +89,10 @@ const fetchTaggings = (dropdownsObject) => {
   $.get({
     url: '/taggings.json',
     dataType: 'json',
-    data: dropdownsObject,
+    data: {
+      content_type: dropdownsObject.content_type,
+      topic_area: dropdownsObject.topic_area.replace("%20", " ")
+    },
   }).done(response => {
     const headerSmallCardsLow = () => {
       $('.find-out__header').removeClass('find-out__header--large');

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -80,7 +80,11 @@ const onDropdownChange = () => {
       topic_area: dropdownSelections[1].text,
     };
     fetchTaggings(dropdownsObject);
-    history.pushState(null, '', `/find-out/${dropdownsObject.content_type}/${dropdownsObject.topic_area}`)
+    if (dropdownsObject.content_type === 'everything' && dropdownsObject.topic_area === 'all topic areas') {
+      history.pushState(null, '', '/find-out');
+    } else {
+      history.pushState(null, '', `/find-out/${dropdownsObject.content_type}/${dropdownsObject.topic_area}`);
+    }
     $('#find-out__overlay').removeClass('find-out__overlay');
   });
 };

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -1,8 +1,7 @@
 $(() => {
-  const urlParams = window.location.pathname.split('/').slice(2);
-  console.log(urlParams)
+  const urlParams = window.location.pathname.split('/').slice(2).map(filter => filter.replace(/%20/g, " "));
   let initialTaggings;
-  if (urlParams[0]) {
+  if (urlParams[0] && urlParams[1]) {
     initialTaggings = {
       content_type: urlParams[0],
       topic_area: urlParams[1],
@@ -23,20 +22,26 @@ function loadDropdowns(initialTaggings) {
     url: '/tags.json',
     dataType: 'json',
   }).done((response) => {
-    const contentTypeSelectOptions = response.filter(tag => tag.data.attributes.tag_type === 'content_type')
-      .slice(0, 3)
-      .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`)
-      .join('');
-    const contentTypeDropdown = (`<select class="content-type__select content-type__dropdown"><option id='all-content-types' value='everything' selected>everything</option>${contentTypeSelectOptions}</select>`)
+    const contentTypeDropdown = (`<select class="content-type__select content-type__dropdown">
+      <option id='all-content-types' value='everything' ${initialTaggings.content_type === 'everything' ? 'selected' : ''}>everything</option>`
+      + response.filter(tag => tag.data.attributes.tag_type === 'content_type')
+        .slice(0, 3)
+        .map((tag) => (`<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title" ${initialTaggings.content_type == tag.data.attributes.title ? 'selected' : 'ex'}>
+        ${tag.data.attributes.title}
+      </option>`))
+      .join('')
+    + `</select>`)
     $('.content-type')[0].innerHTML = `You're looking for ${contentTypeDropdown}`;
 
-    const topicAreaSelectOptions = response.filter(tag => tag.data.attributes.tag_type === 'topic_area')
-      .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`)
-      .join('');
-    const topicAreaDropdown = (`<select class="topic-area__select topic-area__dropdown"><option id='all-topic-areas' value='all topic areas' selected>all topic areas</option>${topicAreaSelectOptions}</select>`);
-    console.log(topicAreaDropdown)
-    $('.topic-area')[0].innerHTML = `in ${topicAreaDropdown}`;
-
+    const topicAreaDropdown = (`<select class="topic-area__select topic-area__dropdown">
+      <option id='all-topic-areas' value='all topic areas' ${initialTaggings.topic_area === 'all-topic-areas' ? 'selected' : ''}>all topic areas</option>`
+      + response.filter(tag => tag.data.attributes.tag_type === 'topic_area')
+        .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title" ${initialTaggings.topic_area === tag.data.attributes.title ? 'selected' : ''}>
+          ${tag.data.attributes.title}
+        </option>`)
+        .join('')
+      + `</select>`);
+      $('.topic-area')[0].innerHTML = `in ${topicAreaDropdown}`;
     onDropdownChange();
     cueOverlay();
   });

--- a/app/javascript/packs/find-out.js
+++ b/app/javascript/packs/find-out.js
@@ -1,14 +1,24 @@
 $(() => {
-  const allTaggings = {
-    content_type: 'everything',
-    topic_area: 'all topic areas',
-  };
-  fetchTaggings(allTaggings);
-  loadDropdowns();
+  const urlParams = window.location.pathname.split('/').slice(2);
+  console.log(urlParams)
+  let initialTaggings;
+  if (urlParams[0]) {
+    initialTaggings = {
+      content_type: urlParams[0],
+      topic_area: urlParams[1],
+    };
+  } else {
+    initialTaggings = {
+      content_type: 'everything',
+      topic_area: 'all topic areas',
+    };
+  }
+  fetchTaggings(initialTaggings);
+  loadDropdowns(initialTaggings);
   $('title')[0].text = 'MetroCommon 2050';
 });
 
-function loadDropdowns() {
+function loadDropdowns(initialTaggings) {
   $.get({
     url: '/tags.json',
     dataType: 'json',
@@ -17,13 +27,14 @@ function loadDropdowns() {
       .slice(0, 3)
       .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`)
       .join('');
-    const contentTypeDropdown = (`<select class="content-type__select content-type__dropdown"><option id='all-content-types' value='everything' selected>everything</option>${contentTypeSelectOptions}</select>`);
+    const contentTypeDropdown = (`<select class="content-type__select content-type__dropdown"><option id='all-content-types' value='everything' selected>everything</option>${contentTypeSelectOptions}</select>`)
     $('.content-type')[0].innerHTML = `You're looking for ${contentTypeDropdown}`;
 
     const topicAreaSelectOptions = response.filter(tag => tag.data.attributes.tag_type === 'topic_area')
       .map(tag => `<option data-id=${tag.data.attributes.id} value=${tag.data.attributes.title} class="find-out__tag-title">${tag.data.attributes.title}</option>`)
       .join('');
     const topicAreaDropdown = (`<select class="topic-area__select topic-area__dropdown"><option id='all-topic-areas' value='all topic areas' selected>all topic areas</option>${topicAreaSelectOptions}</select>`);
+    console.log(topicAreaDropdown)
     $('.topic-area')[0].innerHTML = `in ${topicAreaDropdown}`;
 
     onDropdownChange();

--- a/vendor/extensions/taggings/app/controllers/refinery/taggings/taggings_controller.rb
+++ b/vendor/extensions/taggings/app/controllers/refinery/taggings/taggings_controller.rb
@@ -13,11 +13,13 @@ module Refinery
           .map {|t| TaggingSerializer.new(t).serializable_hash }
 
         respond_to do |f|
-          f.html { present(@page) }
+          f.html {
+            present(@page)
+          }
           f.json { render json: {
             taggings: filtered_taggings_json,
             topic_area_narrative: topic_area_narrative,
-            next_three_events: Refinery::Events::Event.next_three_events
+            next_three_events: Refinery::Events::Event.next_three_events,
             }}
         end
       end

--- a/vendor/extensions/taggings/config/routes.rb
+++ b/vendor/extensions/taggings/config/routes.rb
@@ -1,5 +1,6 @@
 Refinery::Core::Engine.routes.draw do
 
+  get '/find-out/:content_type/:topic_area', to: 'taggings/taggings#index'
   get '/find-out', to: 'taggings/taggings#index'
   get '/data_validation', to: 'taggings/taggings#data_validation'
 


### PR DESCRIPTION
Resolves #484 .

# Why is this change necessary?
The communications team found an increasing need to be able to direct users to a particular subset of information on DigitalHub (for example, all of the reports). However, we were not capturing state on the dropdown filters and could only direct users to `/find-out` and ask that they manually set the filters.

# How does it address the issue?
- Use history.pushState to add a URL change without re-loading the page
- Add a second, more specific route to the find out page that requests a `content_type` and a `topic_area`
- Capture last two pieces of the URL path and store as variables, then use these to drive the endpoint request that dictates what is initially displayed on screen. We already had this sort of functionality in place for the filtering; we just didn't have a way to jump directly to a specific set of filters.

# What side effects does it have?
Three come to mind that may be worth resolving:
1) When the user goes back to "View everything from all topic areas," the url becomes `find-out/everything/all topic areas`. Should we add a conditional so that the default settings causes the URL to go back to default `find-out`?
2) I'm currently grabbing all of the path variables as such:
```
const urlPathVariables = window.location.pathname.split('/').slice(2).map(filter => filter.replace(/%20/g, " "));
```
I'm trusting that there will only be two relevant path variables, and the user hits 404 Page Not Found if another is added (as per the route ruling). Should there be stricter enforcement? Similarly, should we have some sort of verification wherein a faulty filter (like `find-out/articles/public health`) redirects to `find-out`?
3) Currently, both `content_type` and `topic_area` are required. In order to see all publications, then, the URL must be `find-out/publications/all topic areas` instead of `find-out/publications`. How much of an issue is this?