### PR TITLE
Add photo credit to Reports and Announcements

### DIFF
--- a/app/assets/stylesheets/global/_mixins.scss
+++ b/app/assets/stylesheets/global/_mixins.scss
@@ -72,3 +72,13 @@
     width: 100%;
   }
 }
+
+@mixin mobile-image-wrapper {
+  @include media(small) {
+    float: unset;
+    margin: 0;
+    max-width: 100%;
+    padding: 0;
+    width: 100%;
+  }
+}

--- a/app/assets/stylesheets/partials/_footer.scss
+++ b/app/assets/stylesheets/partials/_footer.scss
@@ -1,6 +1,7 @@
 .footer {
   background-color: $color_bg-dark;
   bottom: 0;
+  clear: both;
   color: $color_font-light;
   font-size: $font_size-xsmall;
   transition-duration: 1.5s;

--- a/app/assets/stylesheets/refinery/announcement.scss
+++ b/app/assets/stylesheets/refinery/announcement.scss
@@ -84,14 +84,26 @@
       padding: .5rem 0 1rem;
     }
 
-    .content__image {
-      @include mobile-image;
-
+    .image__wrapper {
+      @include mobile-image-wrapper;
       float: right;
       height: auto;
       margin: 11.25rem 0 .6rem .8rem;
       max-width: 30rem;
       padding: 0 1.35rem 1rem 1rem;
+    }
+
+    .content__image {
+      @include mobile-image;
+    }
+
+    .content__image-credit {
+      color: $color_bg-darkgrey;
+      font-family: $font_family-primary;
+      font-size: $font_size-small;
+      font-style: italic;
+      padding: .5rem 0;
+      text-align: center;
     }
   }
 }

--- a/app/assets/stylesheets/refinery/announcement.scss
+++ b/app/assets/stylesheets/refinery/announcement.scss
@@ -95,6 +95,8 @@
 
     .content__image {
       @include mobile-image;
+      height: auto;
+      max-width: 30rem;
     }
 
     .content__image-credit {

--- a/app/assets/stylesheets/refinery/report.scss
+++ b/app/assets/stylesheets/refinery/report.scss
@@ -86,12 +86,23 @@
       padding: 0.5rem 0 1rem;
     }
 
+    .image__wrapper {
+      @include mobile-image-wrapper;
+      float: right;
+      margin: 0 0 .6rem .8rem;
+    }
+
     .content__image {
       @include mobile-image;
+    }
 
-      float: right;
-      margin: 0 0 0.6rem 0.8rem;
-      max-width: 50%;
+    .content__image-credit {
+      color: $color_bg-darkgrey;
+      font-family: $font_family-primary;
+      font-size: $font_size-small;
+      font-style: italic;
+      padding: .5rem 0;
+      text-align: center;
     }
   }
 }

--- a/app/assets/stylesheets/refinery/report.scss
+++ b/app/assets/stylesheets/refinery/report.scss
@@ -94,6 +94,8 @@
 
     .content__image {
       @include mobile-image;
+      height: auto;
+      max-width: 30rem;
     }
 
     .content__image-credit {

--- a/db/migrate/20200217180346_add_image_credit_to_announcements.rb
+++ b/db/migrate/20200217180346_add_image_credit_to_announcements.rb
@@ -1,0 +1,5 @@
+class AddImageCreditToAnnouncements < ActiveRecord::Migration[5.2]
+  def change
+    add_column :refinery_announcements, :image_credit, :string
+  end
+end

--- a/db/migrate/20200217181316_add_image_credit_to_publications.rb
+++ b/db/migrate/20200217181316_add_image_credit_to_publications.rb
@@ -1,0 +1,5 @@
+class AddImageCreditToPublications < ActiveRecord::Migration[5.2]
+  def change
+    add_column :refinery_reports, :image_credit, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_05_182539) do
+ActiveRecord::Schema.define(version: 2020_02_17_181316) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,7 @@ ActiveRecord::Schema.define(version: 2019_09_05_182539) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "published_date"
+    t.string "image_credit"
   end
 
   create_table "refinery_authentication_devise_roles", id: :serial, force: :cascade do |t|
@@ -259,6 +260,7 @@ ActiveRecord::Schema.define(version: 2019_09_05_182539) do
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "image_credit"
   end
 
   create_table "refinery_resource_translations", id: :serial, force: :cascade do |t|

--- a/vendor/extensions/announcements/app/controllers/refinery/announcements/admin/announcements_controller.rb
+++ b/vendor/extensions/announcements/app/controllers/refinery/announcements/admin/announcements_controller.rb
@@ -33,7 +33,7 @@ module Refinery
 
         # Only allow a trusted parameter "white list" through.
         def announcement_params
-          params.require(:announcement).permit(:title, :body, :published_date, :image_id, :link, :tag)
+          params.require(:announcement).permit(:title, :body, :published_date, :image_id, :link, :tag, :image_credit)
         end
       end
     end

--- a/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
@@ -42,6 +42,8 @@
         :image => @announcement.image,
         :toggle_image_display => false -%>
     </div>
+    <%= f.label :image_credit -%>
+    <%= f.text_field :image_credit -%>
     <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
       <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
         <span class="tags__selector-topic"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -3,7 +3,7 @@
     <div class="v2-banner"></div><!-- top green bar -->
       <div class="content container">
         <% if @announcement.image %>
-          <div className="image__wrapper">
+          <div class="image__wrapper">
             <%= image_tag(@announcement.image.url, class: "content__image") %>
             <div class="content__image-credit"><%= @announcement.image_credit %></div>
           </div>

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -3,7 +3,10 @@
     <div class="v2-banner"></div><!-- top green bar -->
       <div class="content container">
         <% if @announcement.image %>
-          <%= image_tag(@announcement.image.url, class: "content__image") %>
+          <div className="image__wrapper">
+            <%= image_tag(@announcement.image.url, class: "content__image") %>
+            <div class="content__image-credit"><%= @announcement.image_credit %></div>
+          </div>
         <% end %>
         <div class="content__content-type">NEWS</div>
         <div class="content__title"><%= @announcement.title %></div>

--- a/vendor/extensions/reports/app/controllers/refinery/reports/admin/reports_controller.rb
+++ b/vendor/extensions/reports/app/controllers/refinery/reports/admin/reports_controller.rb
@@ -33,7 +33,7 @@ module Refinery
 
         # Only allow a trusted parameter "permit list" through.
         def report_params
-          params.require(:report).permit(:title, :body, :date, :image_id, :link, :tag)
+          params.require(:report).permit(:title, :body, :date, :image_id, :link, :tag, :image_credit)
          end
       end
     end

--- a/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/admin/reports/_form.html.erb
@@ -39,6 +39,8 @@
         :image => @report.image,
         :toggle_image_display => false -%>
     </div>
+    <%= f.label :image_credit -%>
+    <%= f.text_field :image_credit -%>
     <div class='tags__header-topic'>Select at least one (1) Topic Area tag</div>
       <% Refinery::Tags::Tag.all.select {|t| t.tag_type == "topic_area" }.each do |tag| %>
         <span class="tags__selector-topic"><input type="checkbox" name="tag[tag_ids][]" id="tag_<%= tag.id %>" value="<%= tag.id %>"

--- a/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
@@ -10,7 +10,7 @@
     <div class="v2-banner"></div><!-- top green bar -->
       <div class="content container">
         <% if @report.image %>
-          <div className="image__wrapper">
+          <div class="image__wrapper">
             <%= image_tag(@report.image.url, class: "content__image ") %>
             <div class="content__image-credit"><%= @report.image_credit %></div>
           </div>

--- a/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
+++ b/vendor/extensions/reports/app/views/refinery/reports/reports/show.html.erb
@@ -10,7 +10,10 @@
     <div class="v2-banner"></div><!-- top green bar -->
       <div class="content container">
         <% if @report.image %>
-          <%= image_tag(@report.image.url, class: "content__image ") %>
+          <div className="image__wrapper">
+            <%= image_tag(@report.image.url, class: "content__image ") %>
+            <div class="content__image-credit"><%= @report.image_credit %></div>
+          </div>
         <% end %>
         <div class="content__content-type">Publication</div>
         <div class="content__title"><%= @report.title %></div>


### PR DESCRIPTION
Resolves #481  .

# Why is this change necessary?
We didn't have a way of directly attributing image credit to a photographer on reports and announcements, which limited the scope of images we could use attribution-free.

# How does it address the issue?
A couple of migrations to add an `image_credit` attribute to the announcement and report models, then an addition in the creation form to optionally add that in. The CSS was also somewhat reworked to accommodate the new image wrapper (containing image and credit) instead of just the image. Right now I have the credit centered under the image, but I'm happy to change that.

# What side effects does it have?
None, though it should be noted that this can currently only take in a string and not proper HTML (so further development would be needed if we wanted to add links).

I did also take this as an opportunity to edit the announcement image width on mobile like I mentioned in PR #473. If the original was actually the correct version, I'll change it back. 