### PR TITLE
Display links in Announcements pages and carousel

### DIFF
--- a/app/assets/stylesheets/partials/_announcements.scss
+++ b/app/assets/stylesheets/partials/_announcements.scss
@@ -115,6 +115,10 @@
     }
   }
 
+  &__link {
+    color: white;
+  }
+
   @include media(medium) {
     margin: 1.75rem auto .6rem auto;
     // Fix below counteracts refinery putting an :after elemnt after sections with a height of 0.

--- a/app/javascript/packs/carousel.js
+++ b/app/javascript/packs/carousel.js
@@ -65,6 +65,8 @@ function populateAnnouncement(announcement, carouselContainer) {
   paragraphNode.innerHTML = body
   carouselContainer.firstElementChild.appendChild(paragraphNode)
 
+  styleLinks();
+
   let imageNode = document.createElement("img")
   imageNode.setAttribute('src', imageUrl)
   imageNode.setAttribute('srcset', `${image2xUrl} 2x`)
@@ -95,7 +97,6 @@ function genDisplay(data, carouselContainer) {
       data: { attributes: { title, sanitized_body: body, link }},
       included
     } = data[selection];
-
     const {
       attributes: { title: imageTitle = "Default Image",
                     alt: imageAlt = "A default image.",
@@ -107,10 +108,12 @@ function genDisplay(data, carouselContainer) {
     } = included[0]
 
     carouselContainer.querySelector('.announcements__title').innerText = title;
-    carouselContainer.querySelector('.announcements__paragraph').innerText = body;
+    carouselContainer.querySelector('.announcements__paragraph').innerHTML = body;
     carouselContainer.querySelector('.announcements__image').setAttribute('src', imageUrl);
     carouselContainer.querySelector('.announcements__image').setAttribute('alt', imageAlt);
     carouselContainer.querySelector('.announcements__image').setAttribute('srcset', `${image2xUrl} 2x`);
+    styleLinks();
+
     for (var i = 0; i < numbers.length; i++) {
         numbers[i].setAttribute('class', 'announcements__number')
     }
@@ -119,4 +122,11 @@ function genDisplay(data, carouselContainer) {
     carouselContainer.querySelector('.announcements__button').setAttribute('href', link)
   };
   return displayAnnouncement;
+}
+
+function styleLinks() {
+  let linkNodes = document.querySelectorAll('.announcements__paragraph > a')
+  for (let linkIndex = 0; linkIndex < linkNodes.length; linkIndex++) {
+    linkNodes[linkIndex].setAttribute('class', 'announcements__link')
+  }
 }

--- a/vendor/extensions/announcements/app/serializers/announcement_serializer.rb
+++ b/vendor/extensions/announcements/app/serializers/announcement_serializer.rb
@@ -6,6 +6,6 @@ class AnnouncementSerializer
   has_many :tags, :class_name => '::Refinery::Tags::Tag', through: :taggings
 
   attribute :sanitized_body do |record|
-    Rails::Html::WhiteListSanitizer.new.sanitize(record.body)
+    Rails::Html::WhiteListSanitizer.new.sanitize(record.body, tags: %w(a), attributes: %w(href title))
   end
 end

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -15,7 +15,7 @@
         <% end %>
         <div class="content__tags">tags: <%= @tags %></div>
         <div class="content__body">
-          <%= strip_tags @announcement.body %>
+          <%= raw @announcement.body %>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Resolves #509 .

# Why is this change necessary?
Sometimes announcements come with links that need to be included on both the homepage and the individual show page (for example, a mailTo link or a link to an attachment).

# How does it address the issue?
This allows all markup from Refinery to go through to the announcement's show page in the same way that we allow it for reports. Additionally, the `sanitized_body` function was updated for the homepage carousel to allow for anchor tags and their href/title attributes to go through.

# What side effects does it have?
Anytime `:sanitized_body` is called on an Announcement (not just on the homepage), `a` tags will go through. That said, the carousel is the only place it is currently called. Additionally, a new style was added (`announcement__link`) to update the homepage announcement link color from default green to white. If we use this element-level class elsewhere (like on the Announcement show page), we might want to consider bumping this style up to be a modifier instead (`announcement__link--white`)