### PR TITLE
Update  mimemagic library and plugins that depend on it

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'google-cloud-storage'
 gem 'local_time'
 gem 'fast_jsonapi'
 gem "autoprefixer-rails"
+gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: '01f92d86d15d85cfd0f20dabd025dcbd36a8a60f'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: https://github.com/mimemagicrb/mimemagic.git
+  revision: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  ref: 01f92d86d15d85cfd0f20dabd025dcbd36a8a60f
+  specs:
+    mimemagic (0.3.5)
+
+GIT
   remote: https://github.com/refinery/refinerycms-authentication-devise.git
   revision: 485d14f3a9aaadd10fb62b7c34b370101bd2d858
   specs:
@@ -399,10 +406,9 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2018.0812)
-    mimemagic (0.3.3)
     mini_magick (4.9.4)
     mini_mime (1.0.1)
-    mini_portile2 (2.4.0)
+    mini_portile2 (2.6.1)
     minitest (5.14.0)
     mobility (0.8.9)
       i18n (>= 0.6.10, < 2)
@@ -417,8 +423,9 @@ GEM
       net-ssh (>= 2.6.5, < 6.0.0)
     net-ssh (5.2.0)
     nio4r (2.3.1)
-    nokogiri (1.10.9)
-      mini_portile2 (~> 2.4.0)
+    nokogiri (1.12.4)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -446,6 +453,7 @@ GEM
     public_suffix (3.0.3)
     puma (4.3.3)
       nio4r (~> 2.0)
+    racc (1.5.2)
     rack (2.1.1)
     rack-protection (2.0.5)
       rack
@@ -480,7 +488,7 @@ GEM
       method_source
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
-    rake (13.0.1)
+    rake (13.0.6)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -673,6 +681,7 @@ DEPENDENCIES
   guard-rspec
   listen (>= 3.0.5, < 3.2)
   local_time
+  mimemagic!
   mini_magick
   momentjs-rails (~> 2.17, >= 2.17.1)
   parallel


### PR DESCRIPTION
Resolves issues with building and running digital hub locally .

# Why is this change necessary?
Mimemagic was failing because of a licensure change and we were unable to build

# How does it address the issue?
It pulls mimemagic from a specific git sha for that version with the updated license.

# What side effects does it have?
Hopefully none.
