### PR TITLE
Alter annoucements/news for recommendations

### DIFF
--- a/app/assets/stylesheets/global/_vars.scss
+++ b/app/assets/stylesheets/global/_vars.scss
@@ -4,6 +4,7 @@ $font_size-small: 1rem; // 16px
 $font_size-medium: 1.125rem; // 18px
 $font-size-md-large: 1.25rem; // 20px
 $font_size-large: 1.5rem; // 24px
+$font_size-larger: 1.75rem; // 28px
 $font_size-xlarge: 2.1875rem; // 35px
 $font_size-xxlarge: 3.75rem; //60px
 // font sizes in v3 home page
@@ -41,6 +42,8 @@ $v3-color_red-light: #f15b52;
 $v3-color_yellow-light: #fdb521; 
 $v3-color_green-light--dark: mix($v3-color_black-dark, $v3-color_green-light, 15);
 $v3-color_gray-dark: #707070;
+$v3-color_gray-light: #979F9E;
+$v3-color_beige: #f0efe7;
 $v3-color_light-teal: #4cc1b9;
 $v3-color_slate: #f0efe7;
 $v3-color_overlay-dark-green: #03332d;

--- a/app/assets/stylesheets/refinery/_all.scss
+++ b/app/assets/stylesheets/refinery/_all.scss
@@ -9,6 +9,7 @@
 @import 'reports_landing';
 @import 'goals';
 @import 'announcement';
+@import 'recommendation';
 @import 'nice-select';
 @import 'generic';
 @import 'editor';

--- a/app/assets/stylesheets/refinery/announcement.scss
+++ b/app/assets/stylesheets/refinery/announcement.scss
@@ -8,6 +8,7 @@
   }
 
   .container {
+    padding: 0 1.35rem 2rem 1.35rem;
     @include media (small) {
       display: grid;
       margin: 0;
@@ -74,18 +75,19 @@
         grid-row: 6;
         margin-bottom: 1rem;
         min-height: unset;
-        padding: .5rem 1.35rem 1rem;
+        padding: 0 1.35rem 1rem;
       }
 
       color: $v3-color_gray-dark;
       font-size: $font_size-small;
       line-height: 1.5rem;
       min-height: 27.85rem;
-      padding: .5rem 0 1rem;
+      padding: 0 0 1rem;
     }
 
     .image__wrapper {
       @include mobile-image-wrapper;
+      display: none;
       float: right;
       height: auto;
       margin: 11.25rem 0 .6rem .8rem;

--- a/app/assets/stylesheets/refinery/recommendation.scss
+++ b/app/assets/stylesheets/refinery/recommendation.scss
@@ -1,0 +1,101 @@
+.recommendation {
+  &_equity {
+    h2 {
+      color: $v3-color_purple-light;
+    }
+    .recommendation_header {
+      &__contents li::before {
+        border-color: transparent $v3-color_purple-light;
+      }
+      &__link {
+        border: solid 1px $v3-color_purple-light;
+      }
+    }
+  }
+
+  &_header {
+    background-color: $v3-color_beige;
+    display: flex;
+    font-family: $font_family-primary;
+    margin: -10rem;
+    padding: 3rem 15rem;
+
+    div {
+      width: 60%;
+      margin-right: 0.75rem;
+    }
+
+    img {
+      width: 40%;
+    }
+
+    &__section {
+      text-transform: uppercase;
+      font-family: $font_family-secondary;
+    }
+
+    &__title {
+      color: $v3-color_green-dark;
+      line-height: 2.5rem;
+      margin: .5rem 0 0 0;
+    }
+
+    &__area {
+      color: $v3-color_gray-dark;
+      font-size: $font_size-medium;
+    }
+
+    &__contents {
+      list-style-type: none;
+      margin-right: 1rem;
+
+      li {
+        align-items: center;
+        color: $v3-color_gray-dark;
+        display: flex;
+        font-size: $font_size-small;
+        line-height: 1.5em;
+
+        &::before {
+          content: "";
+          border-style: solid;
+          border-width: 0.5em 0 0.5em 0.95em;
+          display: block;
+          height: 0;
+          width: 0;
+          left: -1em;
+          position: relative;
+        }
+      }
+    }
+    &__link {
+      display: inline-block;
+      padding: 1rem 2rem;
+      text-transform: uppercase;
+      text-decoration: none;
+    }
+  }
+
+  &_body {
+    margin: 15rem 5rem;
+    &__strategy {
+      font-size: $font_size-larger;
+    }
+    &__actions {
+      list-style-type: none;
+
+      li {
+        font-weight: bold;
+        color: $v3-color_green-dark;
+
+        ul {
+          list-style-type: none;
+          li {
+            color: $v3-color_gray-light;
+            padding: 1rem;
+          }
+        }
+      }
+    }
+  }
+}

--- a/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/admin/announcements/_form.html.erb
@@ -39,7 +39,7 @@
                   name="announcement[tags][]"
                   id="tag_<%= tag.id %>"
                   value="<%= tag.id %>"
-                  <%= 'checked' if tag.title == "news" %>
+                  <%= 'checked' if tag.title == "recommendations" %>
             >
             <label for="tag_<%= tag.id %>">
               <%= tag.title %>

--- a/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
+++ b/vendor/extensions/announcements/app/views/refinery/announcements/show.html.erb
@@ -2,21 +2,23 @@
   <div class="announcement">
     <div class="v2-banner"></div><!-- top green bar -->
       <div class="content container">
-        <% if @announcement.image %>
+        <%
+=begin%>
+ <% if @announcement.image %>
           <div class="image__wrapper">
             <%= image_tag(@announcement.image.url, class: "content__image") %>
             <div class="content__image-credit"><%= @announcement.image_credit %></div>
           </div>
-        <% end %>
-        <div class="content__content-type">NEWS</div>
-        <div class="content__title"><%= @announcement.title %></div>
+        <% end %> 
+<%
+=end%>
+        <div class="content__body">
+        <%= raw @announcement.body %>
+        </div>
+        <div class="content__tags">tags: <%= @tags %></div>
         <% if @announcement.published_date %>
           <div class="content__date"><%= @announcement.published_date.strftime("%B %d, %Y") %></div>
         <% end %>
-        <div class="content__tags">tags: <%= @tags %></div>
-        <div class="content__body">
-          <%= raw @announcement.body %>
-        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Resolves # .

# Why is this change necessary?
Wanted a way to have recommendations be:
- searchable
- editable
- and sortable in find-out

# How does it address the issue?
Reworked announcements that are no longer being used to fulfill the above requirements

# What side effects does it have?
Hopefully none.

For Setup of Recommendations page add a new announcement in the news tab. Title should begin with "Receommendation:"

<img width="1103" alt="Screen Shot 2021-10-15 at 3 46 31 PM" src="https://user-images.githubusercontent.com/12685178/137545290-0fdbd105-5a23-49e7-b3c4-fe5b3412d7c5.png">

And image has to be chosen, we will eventually upload our own.

Apply the recommendation context in this format (click the html button in the editor to see the classes and elements. Format is as follows:
```
<div class="recommendation_equity">
<div class="recommendation_header">
<div>
<span class="recommendation_header__section">Action Area × Recommendations</span>
<h1 class="recommendation_header__title">Enable wealth creation and intergenerational wealth transfer</h1>
<span class="recommendation_header__area">Action Area: Equity of Wealth and Health</span>
<ul class="recommendation_header__contents">
<li>Action Area: Equity of Wealth and Health</li>
<li>Expand the social safety net to lift families out of poverty.</li>
<li>Create safe, accessible, and well-connected networks of safe cycling and walking infrastructure</li>
<li>Shape new and emerging mobility services to support local and regional transportation goals of safety, reduced traffic congestion, less greenhouse gas emissions, and equitable access for all people</li>
</ul>
<a class="recommendation_header__link" href="/action-areas/equity-wealth-health" title="Download PDF Version">Download PDF Version</a>
</div>
<img src="http://localhost:3000/assets/action_areas-19e399ddcb1f2caf8640026eddf2c069cc46530e3b3bc6fd5009b35217dc0340.png" />
</div>

<div class="recommendation_body">
<h2 class="recommendation_body__strategy">Strategy 1: Enable more people to build and maintain wealth.</h2>
<p>Nationwide, economic mobility has been on the decline for decades. While this trend is evident across the several ways in which people build wealth, including savings, real estate, and investments, it is particularly true with respect to earnings. The proportion of Americans making more than their parents dropped from 92 percent for individuals born in 1940 to 50 percent for individuals born in 1984.1 There are a multitude of factors that have influenced these outcomes, including skyrocketing housing and higher education costs, consolidation of corporate power, wage stagnation, and disintegration of the social safety net. Systemic racism has catalyzed and exacerbated these trends.</p>
<p>In the Commonwealth, the ability to secure a well-paying job, build adequate savings, and gain access to a range of economic opportunity continues to vary sharply across racial lines. While 70 percent of White households in Massachusetts own a home, just over a third of households of color are homeowners. Non-white households are more likely to have student loan and medical debt. And there is the oft-cited disparity of median net worth being close to a quarter million for white households in Metro Boston, but just $8 for non-immigrant Black households in the region.2, 3 In addition to burdens at the individual and community levels, disparities in racial wealth hurt the economy of the Commonwealth as a whole. The Massachusetts Taxpayers Foundation estimates that if Massachusetts were to close racial divides in wages, housing, investments, and wealth, the Massachusetts gross state product could increase $25 billion over five years.4 By limiting the ability to build wealth today, we are setting up future generations for continued inequities in the absence of significant reform.</p>
<p>In addition to the actions described below around increasing wages and access to benefits, expanding the availability of high-quality jobs is also critical to addressing racial disparities in wealth generation and quality of life. Since low-income individuals are disproportionately employed by small businesses,5 strengthening the resiliency of small businesses and promoting their integration to the broader regional economic development landscape will benefits their employees as well. (See “Expand and promote the resiliency of small businesses, particularly those owned by people of color, and encourage large employers to invest in local economies and advance equity” for specific recommendations.) Additionally, more flexible schedules and more predictable work hours would not only help more people retain employment while balancing additional responsibilities, but also improve overall quality of life. (See “Improve quality of life and reverse the rising rate of chronic diseases, particularly among populations experiencing health inequities” for more details on how to offer more workers this kind of stability.) </p>
<ul class="recommendation_body__actions">
<li>Action 1.1: Institute a statewide pilot of universal basic income, based upon the lessons learned from the UBI pilot in Chelsea. Pilot baby bonds and universal basic income. Baby bonds would work in tandem with the existing Massachusetts Baby Steps savings plan, which is the Commonwealth’s universal educational savings programs, and would be reserved for low-income families for assets beyond higher education, such as homeownership. 
<ul>
<li>The COVID-19 pandemic has renewed momentum for universal basic income (UBI), which provides individuals with a small, fixed amount of unrestricted cash provided on a regular basis. Proponents of UBI highlight the flexibility of the relief provided as a primary benefit of the program. Unlike other forms of aid, which recipients can use for specific purposes such as education, housing costs, or groceries, UBI programs provide residents with the flexibility to spend funds where they are most needed. While cities around the country have been piloting UBI during the pandemic to support individuals most impacted by the economic consequences of COVID-19, other government entities have long provided their residents with guaranteed income. Shortly after it achieved statehood, Alaska created a state-owned investment fund to hold oil proceeds, and dividends from that fund have been paid out to residents for the last 40 years.7 Since 1997, the Eastern Band of Cherokees established a casino dividend program that would distribute a portion of casino revenue to all reservation residents.  Importantly, studies have found that these two programs have had no demonstrable effect on labor force participation, and, in the case of the Eastern Band of Cherokees, program participants experienced improved mental health outcomes in the long-term.8 The Commonwealth should advance a guaranteed income pilot, potentially using federal pandemic recovery dollars to fund the program. The state could limit the pilot to individuals under a certain income threshold, and should require a robust data collection effort to determine how funds are utilized as well as what resources would be needed to sustain the program in the long term.</li>
<li>Working in tandem with universal basic income, baby bonds can help address some of the disparities in wealth early on, before they are exacerbated into adulthood. Economists William Darity and Darrick Hamilton have led renewed interest in baby bonds to reduce the racial wealth gap. Baby bonds are typically publicly funded trust fund accounts provided at birth. Contributions would be made annually, with the largest contributions going to low-income families. Individuals are generally able to access the funds at age 18, and can only use them for wealth building purposes, such as purchasing a home, starting a business, or getting an education. At the federal level, Sen. Cory Booker (D-NJ) and Rep. Ayanna Pressley (D-MA-7) have proposed the American Opportunity Accounts Act, which would create a national baby bonds program. Each child’s account would receive an initial $1,000 deposit, with additional contributions made annually. Children from the lowest-income households would receive the maximum annual contribution of $2,000. Recently, Connecticut became the first state in the nation to implement a statewide baby bonds program. After July 1, 2021, children in Connecticut whose birth is covered under the state’s Medicaid program are eligible to receive $3,200 in a trust account, which will accumulate until the child is able to access the fund at age 18.9The Commonwealth should institute its own baby bonds program to work in tandem with the existing Massachusetts Baby Steps savings plan, the state’s universal educational savings program. These efforts should happen alongside an expansion of the Family Self Sufficiency (FSS) program (see Action 2.1)</li>
</ul>
</li>
<li>Action 1.2: Finance tuition free community college for low-income individuals, including older adults. The Commonwealth should look to the City of Boston’s Tuition Free Community College initiative to structure a comparable statewide program that takes into account student income, eligibility for federal aid, and other factors.</li>
<li>Action 1.3: Expand access to retirement savings accounts for freelance and contract workers through portable benefits solutions and other state-sponsored options. </li>
<li>Action 1.4: Create a statewide commission to study the use of reparations in Massachusetts. </li>
</ul>
</div>
</div>
```


