### PR TITLE
Fix file name that was causing an error on staging

### DIFF
--- a/app/views/refinery/shared/copy/action-areas/climate/_recommendations_grid.html.erb
+++ b/app/views/refinery/shared/copy/action-areas/climate/_recommendations_grid.html.erb
@@ -20,7 +20,7 @@
     </div>
 </a>
 <a class="action-areas-recommendations__grid-container" href="/announcements/recommendations/20">
-    <%= image_tag("recommendations/climate-4", alt: t("An aerial view of billowing fumes from factories")) %>
+    <%= image_tag("recommendations/climate-4.jpg", alt: t("An aerial view of billowing fumes from factories")) %>
     <div class="action-areas-recommendations__grid-copy">
         <p class="action-areas-recommendations__grid-copy-recc">Recommendation</p>
         <p class="action-areas-recommendations__grid-copy-recc-title">Decarbonize the building and transportation sectors</p>


### PR DESCRIPTION
 The .jpg file extension was missing on the staging server and the climate page couldn't load.
