### PR TITLE
Fixed action area carousel links to work from different paths

### DIFF
--- a/app/views/refinery/shared/_action_areas_carousel.html.erb
+++ b/app/views/refinery/shared/_action_areas_carousel.html.erb
@@ -4,31 +4,31 @@
       <span class="action-areas-carousel-card__type">Action Area</span>
       <span class="action-areas-carousel-card__title">Inclusive Growth & Mobility</span>
       <span class="action-areas-carousel-card__copy">The ways we get around in Greater Boston – and where and how we grow – has profound effects. How do we manage land use and transportation for the benefit of all?</span>
-      <a class="action-areas-carousel-card__link" href="action-areas/growth-mobility">Read More</a>
+      <a class="action-areas-carousel-card__link" href="../action-areas/growth-mobility">Read More</a>
     </li>
     <li class="action-areas-carousel-card">
       <span class="action-areas-carousel-card__type">Action Area</span>
       <span class="action-areas-carousel-card__title">Homes for Everyone</span>
       <span class="action-areas-carousel-card__copy">Greater Boston’s housing crisis devastates the cost-burdened, hurts the region’s quality of life, and weakens its economic competitiveness. How do we create more places to live, and protect against displacement?</span>
-      <a class="action-areas-carousel-card__link" href="action-areas/housing">Read More</a>
+      <a class="action-areas-carousel-card__link" href="../action-areas/housing">Read More</a>
     </li>
     <li class="action-areas-carousel-card">
       <span class="action-areas-carousel-card__type">Action Area</span>
       <span class="action-areas-carousel-card__title">Equity of Wealth & Health</span>
       <span class="action-areas-carousel-card__copy">Disparities in health and wealth associated with race are not unique to Greater Boston, but they harm everyone. How do we close and redress these gaps – at a structural level?</span>
-      <a class="action-areas-carousel-card__link" href="action-areas/equity-wealth-health">Read More</a>
+      <a class="action-areas-carousel-card__link" href="../action-areas/equity-wealth-health">Read More</a>
     </li>
     <li class="action-areas-carousel-card">
       <span class="action-areas-carousel-card__type">Action Area</span>
       <span class="action-areas-carousel-card__title">Dynamic & Representative Government</span>
       <span class="action-areas-carousel-card__copy">Greater Boston has a long, proud history of local control. But some challenges – like housing and climate – know no borders. How do our municipalities become more effective – and more inclusive?</span>
-      <a class="action-areas-carousel-card__link" href="action-areas/governance">Read More</a>
+      <a class="action-areas-carousel-card__link" href="../action-areas/governance">Read More</a>
     </li>
     <li class="action-areas-carousel-card">
       <span class="action-areas-carousel-card__type">Action Area</span>
       <span class="action-areas-carousel-card__title">Climate Mitigation & Resiliency</span>
       <span class="action-areas-carousel-card__copy">Climate change is already altering our lives, and this will only intensify. How can we mitigate climate change and adapt to its effects now, to be better off by 2050?</span>
-      <a class="action-areas-carousel-card__link" href="action-areas/climate">Read More</a>
+      <a class="action-areas-carousel-card__link" href="../action-areas/climate">Read More</a>
     </li>
   </ul>
 </main>


### PR DESCRIPTION
Action areas carousel links were not working from the action areas individual pages. They are working now.
