### PR TITLE
Add position fixed to body of Overview when pop up letter is displayed

### DIFF
--- a/app/assets/stylesheets/refinery/reports_landing.scss
+++ b/app/assets/stylesheets/refinery/reports_landing.scss
@@ -57,7 +57,7 @@
       cursor: pointer;
       font-family: $font_family-secondary-light;
       font-size: $font_size-larger;
-      margin: 7.5rem 11rem;
+      margin: 14vh 14vw;
       max-height: 80vh;
       max-width: 80vw;
       position: absolute;

--- a/app/views/refinery/pages/reports_landing.html.erb
+++ b/app/views/refinery/pages/reports_landing.html.erb
@@ -1,11 +1,14 @@
 <script>
     window.onload = init;
     function init() {
+        const body = document.body;
         const letter = document.getElementById("reports-letter");
         const close = document.getElementById("reports-letter-close");
         letter.style.display = "flex";
+        body.style.position = "fixed";
         function hide() {
             letter.style.display = "none";
+            body.style.position = "relative";
         }
         close.addEventListener("click", hide);
     };


### PR DESCRIPTION
Resolves #535  .

# Why is this change necessary?

I added dynamic styling to set the body position as fixed at window.onload to prevent scrolling, when the popup letter is displayed. On close of the letter, the body position is changed to relative to allow for scrolling.

# How does it address the issue?

# What side effects does it have?
