### PR TITLE
Add pdf download link to navigation_site partial on Overview page

### DIFF
--- a/app/assets/stylesheets/partials/_navigation_site.scss
+++ b/app/assets/stylesheets/partials/_navigation_site.scss
@@ -22,9 +22,18 @@
     }
 
     a {
+      text-decoration: none;
+      &:hover {
+        color: $v3-color_green-light;
+      }
+    }
+
+    li > a {
       bottom: 0.3125rem;
       color: $v3-color_gray-dark;
-      text-decoration: none;
+      &:hover {
+        color: $v3-color_green-light;
+      }
     }
 
     h4 {

--- a/app/views/refinery/shared/_navigation_site.html.erb
+++ b/app/views/refinery/shared/_navigation_site.html.erb
@@ -4,10 +4,13 @@
             <div class="navigation-site-content__col-1">
                 <h4>Location</h4>
                 <p>Greater Boston</p>
-            </div>
-            <div class="navigation-site-content__col-2">
                 <h4>Focus Areas</h4>
                 <p>2050</p>
+            </div>
+            <div class="navigation-site-content__col-2">
+                <h4>Download PDF</h4>
+                <a href="/"><p>Version 1.0</p></a>
+
             </div>
             <div class="navigation-site-content__col-3">
                 <h4>Jump-To Pages</h4>


### PR DESCRIPTION
(Partially) Resolves #574  .

# Why is this change necessary?

Created a link to download the full pdf within _navigation_site partial, displayed on the Overview page.

# How does it address the issue?

# What side effects does it have?

We still need the pdf itself for the link.
