### PR TITLE
Adjust z-index's to avoid logo overlay on letter pop up

### DIFF
--- a/app/assets/stylesheets/refinery/reports_landing.scss
+++ b/app/assets/stylesheets/refinery/reports_landing.scss
@@ -48,7 +48,7 @@
     position: absolute;
     transition: all 0.4s ease-in-out;
     width: 100vw;
-    z-index: 1;
+    z-index: 2;
     h1 {
       color: $v3-color_green-dark;
       font-size: $font_size-xlarge;
@@ -63,7 +63,7 @@
       position: absolute;
       right: 0;
       top: 0;
-      z-index: 1;
+      z-index: 3;
     }
     &-text {
       background-color: $color_bg-lightest;


### PR DESCRIPTION
Resolves # .

# Why is this change necessary?

The page break triangle and MAPC logo overlapped the pop up letter on the Overview page. Adjusted z-index's to bring the letter forward.

# How does it address the issue?

# What side effects does it have?
