### PR TITLE
Disable See All Research one box

### DIFF
--- a/app/views/refinery/pages/home.html.erb
+++ b/app/views/refinery/pages/home.html.erb
@@ -67,9 +67,6 @@
                 <% end %>
               </div>
             <% end %>
-            <div class="grid__cell">
-              <%= render partial: '/partials/research_box', locals: { events: @next_events } %>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Resolves #624  .

# Why is this change necessary?

Previous research one box linked to events. Removed the rendering of the partial but not the partial itself for future use.

# How does it address the issue?

# What side effects does it have?
