### PR TITLE
Darken font for recommendation intros

### DIFF
--- a/app/assets/stylesheets/refinery/recommendation.scss
+++ b/app/assets/stylesheets/refinery/recommendation.scss
@@ -195,7 +195,7 @@
       font-size: $font_size-larger;
     }
     p {
-      color: $v3-color_gray-light;
+      color: $v3-color_black-dark;
     }
     &__actions {
       list-style-type: none;


### PR DESCRIPTION
Resolves #669  .

# Why is this change necessary?

Darkened intro paragraphs on recommendation pages.

# How does it address the issue?

# What side effects does it have?
